### PR TITLE
Add CAN monitor tests with virtual bus and DBC

### DIFF
--- a/src/ForRajesh.dbc
+++ b/src/ForRajesh.dbc
@@ -1,0 +1,41 @@
+VERSION ""
+
+NS_ :
+    NS_DESC_
+    CM_
+    BA_DEF_
+    BA_
+    VAL_
+    CAT_DEF_
+    CAT_
+    FILTER
+    BA_DEF_DEF_
+    EV_DATA_
+    ENVVAR_DATA_
+    SGTYPE_
+    SGTYPE_VAL_
+    BA_DEF_SGTYPE_
+    BA_SGTYPE_
+    SIG_TYPE_REF_
+    VAL_TABLE_
+    SIG_GROUP_
+    SIG_VALTYPE_
+    SIGTYPE_VALTYPE_
+    BO_TX_BU_
+    BA_DEF_REL_
+    BA_REL_
+    BA_DEF_DEF_REL_
+    BU_SG_REL_
+    BU_EV_REL_
+    BU_BO_REL_
+    SG_MUL_VAL_
+
+BS_:
+
+BU_: Vector__XXX
+
+BO_ 2566869221 SAMPLE_MSG: 8 Vector__XXX
+ SG_ SPEED : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ TEMP : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+
+CM_ BO_ 2566869221 "Sample message for tests";

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -1,0 +1,155 @@
+import logging
+import os
+import uuid
+from unittest.mock import patch
+
+import can
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from can_monitor import load_dbc, monitor
+
+if not hasattr(can.bus.BusState, "BUS_OFF"):
+    setattr(can.bus.BusState, "BUS_OFF", can.bus.BusState.ERROR)
+
+
+@pytest.fixture
+def log_setup(tmp_path):
+    """Provide a logger writing to a temporary file."""
+    log_file = tmp_path / "can.log"
+    logger = logging.getLogger(f"test_{uuid.uuid4().hex}")
+    logger.setLevel(logging.INFO)
+    handler = logging.FileHandler(log_file)
+    logger.addHandler(handler)
+    logger.propagate = False
+
+    def info(msg, *args, **kwargs):
+        formatted = msg.replace("%%", "%") % args
+        logger._log(logging.INFO, formatted, (), **kwargs)
+
+    logger.info = info  # type: ignore[assignment]
+
+    try:
+        yield logger, log_file
+    finally:
+        logger.removeHandler(handler)
+
+
+dbc_path = os.path.join(os.path.dirname(__file__), "..", "src", "ForRajesh.dbc")
+
+
+@pytest.mark.parametrize("bitrate", [125000, 500000])
+def test_monitor_decodes_extended_ids(bitrate, log_setup):
+    logger, log_file = log_setup
+    db = load_dbc(dbc_path)
+    bus = can.interface.Bus(bustype="virtual", bitrate=bitrate, receive_own_messages=True)
+
+    msg = can.Message(
+        arbitration_id=0x18FF50E5,
+        is_extended_id=True,
+        data=bytes([10, 20, 0, 0, 0, 0, 0, 0]),
+    )
+    bus.send(msg)
+
+    orig_recv = bus.recv
+    calls = 0
+
+    def fake_recv(timeout=1.0):
+        nonlocal calls
+        if calls == 0:
+            calls += 1
+            return orig_recv(timeout)
+        raise can.CanError("stop")
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv):
+            monitor(bus, db, logger)
+
+    contents = log_file.read_text()
+    assert "RAW  id=0x18FF50E5" in contents
+    assert "DECODED id=0x18FF50E5 {'SPEED': 10, 'TEMP': 20}" in contents
+
+
+def test_bus_off_raises_can_error(log_setup, monkeypatch):
+    logger, _ = log_setup
+    monkeypatch.setattr(can.bus.BusState, "BUS_OFF", can.bus.BusState.ERROR, raising=False)
+    bus = can.interface.Bus(bustype="virtual", bitrate=500000, receive_own_messages=True)
+    monkeypatch.setattr(bus.__class__, "state", property(lambda self: can.bus.BusState.BUS_OFF))
+    msg = can.Message(arbitration_id=0x18FF50E5, is_extended_id=True, data=bytes(8))
+
+    def fake_recv(timeout=1.0):
+        return msg
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv):
+            monitor(bus, None, logger)
+
+
+def test_monitor_handles_missing_dbc(log_setup):
+    logger, log_file = log_setup
+    db = None
+    bus = can.interface.Bus(bustype="virtual", bitrate=500000, receive_own_messages=True)
+    msg = can.Message(
+        arbitration_id=0x18FF50E5,
+        is_extended_id=True,
+        data=bytes([1, 2, 0, 0, 0, 0, 0, 0]),
+    )
+    bus.send(msg)
+    orig_recv = bus.recv
+    calls = 0
+
+    def fake_recv(timeout=1.0):
+        nonlocal calls
+        if calls == 0:
+            calls += 1
+            return orig_recv(timeout)
+        raise can.CanError("stop")
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv):
+            monitor(bus, db, logger)
+
+    contents = log_file.read_text()
+    assert "RAW  id=0x18FF50E5" in contents
+    assert "DECODED" not in contents
+
+
+def test_monitor_handles_malformed_frame(log_setup):
+    logger, log_file = log_setup
+    db = load_dbc(dbc_path)
+    bus = can.interface.Bus(bustype="virtual", bitrate=500000, receive_own_messages=True)
+    msg = can.Message(arbitration_id=0x18FF50E5, is_extended_id=True, data=bytes([1]))
+    bus.send(msg)
+    orig_recv = bus.recv
+    calls = 0
+
+    def fake_recv(timeout=1.0):
+        nonlocal calls
+        if calls == 0:
+            calls += 1
+            return orig_recv(timeout)
+        raise can.CanError("stop")
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv):
+            monitor(bus, db, logger)
+
+    contents = log_file.read_text()
+    assert "RAW  id=0x18FF50E5" in contents
+    assert "DECODED" not in contents
+
+
+def test_load_dbc_missing_file(caplog, monkeypatch):
+    def warn(msg, *args, **kwargs):
+        logging.getLogger()._log(logging.WARNING, msg.replace("%%", "%") % args, (), **kwargs)
+
+    monkeypatch.setattr(logging, "warning", warn)
+
+    with caplog.at_level(logging.WARNING):
+        db = load_dbc("does_not_exist.dbc")
+    assert db is None
+    assert "DBC file not found" in caplog.text


### PR DESCRIPTION
## Summary
- add sample ForRajesh.dbc for testing
- add pytest suite using python-can virtual bus to validate decoding, bus-off handling, missing DBC, and malformed frames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fcc0771b88324944322b677aad926