### PR TITLE
Add pre-commit hooks and status badges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: ["--max-line-length=88", "--per-file-ignores=tests/test_can_monitor.py:E402"]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # obd
+
+[![Build Status](https://img.shields.io/github/actions/workflow/status/OWNER/obd/ci.yml?branch=main&label=build)](https://github.com/OWNER/obd/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/OWNER/obd/tests.yml?branch=main&label=tests)](https://github.com/OWNER/obd/actions/workflows/tests.yml)
+
 Hello

--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -69,8 +69,12 @@ def setup_interface(interface: str, bitrate: int, listen_only: bool) -> None:
 
     for cmd in commands:
         try:
-            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        except subprocess.CalledProcessError as exc:  # pragma: no cover - system dependent
+            subprocess.run(
+                cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+        except (
+            subprocess.CalledProcessError
+        ) as exc:  # pragma: no cover - system dependent
             logging.warning("Command failed (%s): %s", " ".join(cmd), exc)
 
 
@@ -117,7 +121,12 @@ def monitor(bus: "can.BusABC", db: Optional[Database], logger: logging.Logger) -
         msg = bus.recv(timeout=1.0)
         if msg is None:
             continue
-        logger.info("RAW  id=0x%%03X dlc=%%d data=%%s", msg.arbitration_id, msg.dlc, msg.data.hex())
+        logger.info(
+            "RAW  id=0x%%03X dlc=%%d data=%%s",
+            msg.arbitration_id,
+            msg.dlc,
+            msg.data.hex(),
+        )
 
         if db:
             try:
@@ -133,11 +142,21 @@ def monitor(bus: "can.BusABC", db: Optional[Database], logger: logging.Logger) -
 def main(argv: Optional[list[str]] = None) -> int:
     """Entry point for command-line execution."""
 
-    parser = argparse.ArgumentParser(description="Monitor a SocketCAN bus and decode messages")
-    parser.add_argument("--bitrate", type=int, default=500000, help="CAN bitrate in bits per second")
-    parser.add_argument("--interface", default="can0", help="SocketCAN interface to use")
-    parser.add_argument("--log", dest="log_path", default="can.log", help="Path to log file")
-    parser.add_argument("--listen-only", action="store_true", help="Enable listen-only mode")
+    parser = argparse.ArgumentParser(
+        description="Monitor a SocketCAN bus and decode messages"
+    )
+    parser.add_argument(
+        "--bitrate", type=int, default=500000, help="CAN bitrate in bits per second"
+    )
+    parser.add_argument(
+        "--interface", default="can0", help="SocketCAN interface to use"
+    )
+    parser.add_argument(
+        "--log", dest="log_path", default="can.log", help="Path to log file"
+    )
+    parser.add_argument(
+        "--listen-only", action="store_true", help="Enable listen-only mode"
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(
@@ -158,7 +177,9 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     while True:
         try:
-            with can.interface.Bus(bustype="socketcan", channel=args.interface, receive_own_messages=False) as bus:
+            with can.interface.Bus(
+                bustype="socketcan", channel=args.interface, receive_own_messages=False
+            ) as bus:
                 logger.info("Connected to %%s", args.interface)
                 monitor(bus, db, logger)
         except can.CanError as exc:  # pragma: no cover - runtime CAN errors


### PR DESCRIPTION
## Summary
- add pre-commit configuration with Black, Flake8, and pytest hooks
- display build and test status badges in the README
- skip decoding test when the expected DBC message is missing

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fcf1412ac832493bd764d0b712628