### PR TITLE
Add serialization and transport modules with retries

### DIFF
--- a/src/serialization.py
+++ b/src/serialization.py
@@ -1,0 +1,32 @@
+"""Utilities for serializing CAN frames."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import Any, Dict, Optional
+
+
+def serialize_frame(arbitration_id: int, data: bytes, decoded: Optional[Dict[str, Any]], fmt: str) -> str:
+    """Serialize a decoded CAN frame.
+
+    Parameters
+    ----------
+    arbitration_id:
+        Frame identifier.
+    data:
+        Raw data bytes.
+    decoded:
+        Decoded payload dictionary or ``None``.
+    fmt:
+        Serialization format: ``"json"`` or ``"csv"``.
+    """
+    frame = {"id": arbitration_id, "raw": data.hex(), "decoded": decoded}
+    if fmt == "json":
+        return json.dumps(frame)
+    if fmt == "csv":
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow([frame["id"], frame["raw"], json.dumps(frame["decoded"])] )
+        return output.getvalue().strip()
+    raise ValueError(f"Unknown format: {fmt}")

--- a/src/transport.py
+++ b/src/transport.py
@@ -1,0 +1,62 @@
+"""Transport modules for sending serialized frames."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import time
+from typing import Any, Dict, Optional
+
+
+class Transport(ABC):
+    """Abstract transport with retry logic."""
+
+    def __init__(self, retries: int = 3, delay: float = 0.5) -> None:
+        self.retries = retries
+        self.delay = delay
+
+    def send(self, payload: str) -> None:
+        attempts = 0
+        while True:
+            try:
+                self._send_once(payload)
+                return
+            except Exception:
+                attempts += 1
+                if attempts >= self.retries:
+                    raise
+                time.sleep(self.delay)
+
+    @abstractmethod
+    def _send_once(self, payload: str) -> None:
+        """Send the payload a single time."""
+
+
+class HTTPTransport(Transport):
+    """HTTP POST transport."""
+
+    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.url = url
+        self.headers = headers or {}
+
+    def _send_once(self, payload: str) -> None:  # pragma: no cover - network errors not deterministic
+        from urllib import request
+
+        req = request.Request(self.url, data=payload.encode(), headers=self.headers, method="POST")
+        with request.urlopen(req) as resp:
+            resp.read()
+
+
+class MQTTTransport(Transport):
+    """MQTT transport using ``paho-mqtt``."""
+
+    def __init__(self, topic: str, hostname: str = "localhost", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.topic = topic
+        self.hostname = hostname
+
+    def _send_once(self, payload: str) -> None:  # pragma: no cover - depends on external lib
+        try:
+            from paho.mqtt import publish
+        except Exception as exc:  # ImportError
+            raise RuntimeError("paho-mqtt is required for MQTTTransport") from exc
+        publish.single(self.topic, payload=payload, hostname=self.hostname)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,162 @@
+import json
+import os
+import threading
+import logging
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+import can
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from can_monitor import load_dbc, monitor
+from serialization import serialize_frame
+from transport import HTTPTransport, MQTTTransport
+
+
+dbc_path = os.path.join(os.path.dirname(__file__), "..", "src", "OBD.dbc")
+
+
+@pytest.fixture
+def log_setup(tmp_path):
+    log_file = tmp_path / "can.log"
+    logger = logging.getLogger(f"test_{uuid.uuid4().hex}")
+    logger.setLevel(logging.INFO)
+    handler = logging.FileHandler(log_file)
+    logger.addHandler(handler)
+    logger.propagate = False
+
+    def info(msg, *args, **kwargs):
+        formatted = msg.replace("%%", "%") % args
+        logger._log(logging.INFO, formatted, (), **kwargs)
+
+    logger.info = info  # type: ignore[assignment]
+
+    try:
+        yield logger, log_file
+    finally:
+        logger.removeHandler(handler)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode()
+        self.server.calls += 1
+        self.server.payloads.append(body)
+        if self.server.fail_first and self.server.calls == 1:
+            self.send_response(500)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.end_headers()
+
+
+def _run_server(server: HTTPServer) -> None:
+    with server:
+        server.serve_forever()
+
+
+@pytest.mark.parametrize("fmt", ["json", "csv"])
+def test_http_transport_formats(fmt, log_setup):
+    logger, _ = log_setup
+    db = load_dbc(dbc_path)
+
+    server = HTTPServer(("localhost", 0), _Handler)
+    server.calls = 0  # type: ignore[attr-defined]
+    server.payloads = []  # type: ignore[attr-defined]
+    server.fail_first = False  # type: ignore[attr-defined]
+    thread = threading.Thread(target=_run_server, args=(server,), daemon=True)
+    thread.start()
+    url = f"http://localhost:{server.server_port}"
+    headers = {"Content-Type": "application/json" if fmt == "json" else "text/csv"}
+    transport = HTTPTransport(url, headers=headers, retries=1, delay=0)
+
+    bus = can.interface.Bus(bustype="virtual", bitrate=500000, receive_own_messages=True)
+    msg = can.Message(arbitration_id=db.messages[0].frame_id, is_extended_id=True, data=bytes([1, 2, 0, 0, 0, 0, 0, 0]))
+    bus.send(msg)
+
+    orig_recv = bus.recv
+    calls = 0
+
+    def fake_recv(timeout=1.0):
+        nonlocal calls
+        if calls == 0:
+            calls += 1
+            return orig_recv(timeout)
+        raise can.CanError("stop")
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv):
+            monitor(bus, db, logger, serializer=fmt, transport=transport)
+
+    server.shutdown()
+    thread.join(1)
+
+    assert server.calls == 1  # type: ignore[attr-defined]
+    payload = server.payloads[0]  # type: ignore[index]
+    if fmt == "json":
+        body = json.loads(payload)
+        assert body["id"] == msg.arbitration_id
+        assert body["raw"] == msg.data.hex()
+    else:
+        expected = serialize_frame(msg.arbitration_id, msg.data, db.decode_message(msg.arbitration_id, msg.data), "csv")
+        assert payload.strip() == expected
+
+
+def test_http_transport_retry(log_setup):
+    logger, _ = log_setup
+    db = load_dbc(dbc_path)
+
+    server = HTTPServer(("localhost", 0), _Handler)
+    server.calls = 0  # type: ignore[attr-defined]
+    server.payloads = []  # type: ignore[attr-defined]
+    server.fail_first = True  # type: ignore[attr-defined]
+    thread = threading.Thread(target=_run_server, args=(server,), daemon=True)
+    thread.start()
+    url = f"http://localhost:{server.server_port}"
+    transport = HTTPTransport(url, headers={"Content-Type": "application/json"}, retries=2, delay=0)
+
+    bus = can.interface.Bus(bustype="virtual", bitrate=500000, receive_own_messages=True)
+    msg = can.Message(arbitration_id=db.messages[0].frame_id, is_extended_id=True, data=bytes([1, 2, 0, 0, 0, 0, 0, 0]))
+    bus.send(msg)
+
+    orig_recv = bus.recv
+    calls = 0
+
+    def fake_recv(timeout=1.0):
+        nonlocal calls
+        if calls == 0:
+            calls += 1
+            return orig_recv(timeout)
+        raise can.CanError("stop")
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv):
+            monitor(bus, db, logger, serializer="json", transport=transport)
+
+    server.shutdown()
+    thread.join(1)
+    assert server.calls == 2  # type: ignore[attr-defined]
+
+
+def test_mqtt_transport_retry(monkeypatch):
+    import paho.mqtt.publish as publish
+
+    call_count = {"n": 0}
+
+    def fake_single(topic, payload=None, hostname=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise OSError("fail")
+        assert payload == "data"
+
+    monkeypatch.setattr(publish, "single", fake_single)
+
+    transport = MQTTTransport("topic", hostname="localhost", retries=2, delay=0)
+    transport.send("data")
+    assert call_count["n"] == 2


### PR DESCRIPTION
## Summary
- Add JSON/CSV serialization helper and integrate optional frame export into `monitor`
- Implement pluggable HTTP and MQTT transports with built-in retry logic
- Test payload formats and retry behavior with mock HTTP server and patched MQTT publish

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd4d315bc8324ba5d8bf82cc110c9