### PR TITLE
refactor: abstract CAN setup commands

### DIFF
--- a/src/canbus/__init__.py
+++ b/src/canbus/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for CAN bus management."""
+
+from .setup import setup_interface, SystemCommands, MockCommands
+
+__all__ = ["setup_interface", "SystemCommands", "MockCommands"]

--- a/src/canbus/setup.py
+++ b/src/canbus/setup.py
@@ -1,0 +1,100 @@
+"""CAN bus setup utilities.
+
+This module centralizes system-level commands required to configure a
+SocketCAN interface.  A pluggable command interface allows the commands to
+be mocked during unit tests or replaced for alternative hardware variants.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Protocol, Sequence
+
+
+class CommandRunner(Protocol):
+    """Protocol for objects capable of running system commands."""
+
+    def modprobe(self, module: str) -> int:
+        """Load a kernel module."""
+
+    def ip(self, args: Sequence[str]) -> int:
+        """Run an ``ip`` command with the given arguments."""
+
+
+class SystemCommands:
+    """Run commands on the host system using :func:`os.system`."""
+
+    def modprobe(self, module: str) -> int:
+        return os.system(f"modprobe {module}")
+
+    def ip(self, args: Sequence[str]) -> int:
+        return os.system("ip " + " ".join(args))
+
+
+class MockCommands:
+    """Record commands instead of executing them.
+
+    This implementation is useful in unit tests where side effects are
+    undesirable.  Commands are stored in the :attr:`commands` list.
+    """
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    def modprobe(self, module: str) -> int:  # pragma: no cover - simple
+        cmd = f"modprobe {module}"
+        self.commands.append(cmd)
+        return 0
+
+    def ip(self, args: Sequence[str]) -> int:  # pragma: no cover - simple
+        cmd = "ip " + " ".join(args)
+        self.commands.append(cmd)
+        return 0
+
+
+def setup_interface(
+    interface: str,
+    bitrate: int,
+    listen_only: bool = False,
+    *,
+    commands: CommandRunner | None = None,
+) -> None:
+    """Configure a SocketCAN interface.
+
+    Parameters
+    ----------
+    interface:
+        Name of the interface (e.g. ``"can0"``).
+    bitrate:
+        Bus bitrate in bits per second.
+    listen_only:
+        If ``True``, the interface is placed in listen-only mode.
+    commands:
+        Optional command runner.  Defaults to :class:`SystemCommands`.
+    """
+
+    cmd = commands or SystemCommands()
+
+    if cmd.modprobe("can") != 0:
+        logging.warning("Failed to load 'can' kernel module")
+    if cmd.modprobe("can_raw") != 0:
+        logging.warning("Failed to load 'can_raw' kernel module")
+    if cmd.ip(["link", "set", interface, "down"]) != 0:
+        logging.warning("Failed to bring down %s", interface)
+
+    ip_args = [
+        "link",
+        "set",
+        interface,
+        "up",
+        "type",
+        "can",
+        "bitrate",
+        str(bitrate),
+    ]
+    if listen_only:
+        ip_args += ["listen-only", "on"]
+
+    if cmd.ip(ip_args) != 0:
+        logging.warning("Failed to configure %s", interface)

--- a/tests/test_canbus_setup.py
+++ b/tests/test_canbus_setup.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from canbus.setup import MockCommands, setup_interface  # noqa: E402
+
+
+def test_setup_interface_builds_commands():
+    mock = MockCommands()
+    setup_interface("can0", 250000, True, commands=mock)
+    assert mock.commands == [
+        "modprobe can",
+        "modprobe can_raw",
+        "ip link set can0 down",
+        "ip link set can0 up type can bitrate 250000 listen-only on",
+    ]


### PR DESCRIPTION
## Summary
- centralize CAN interface setup in new `canbus.setup` module
- allow command execution to be mocked for tests
- switch main monitor script to use new abstraction and add unit tests

## Testing
- `pytest`
- `pre-commit run --files src/can_monitor.py src/canbus/__init__.py src/canbus/setup.py tests/test_canbus_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd693d5a48324aaa64759cbcea468