### PR TITLE
Track and expose CAN bus metrics

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,91 @@
+"""Simple in-process metrics collection and exposure."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, Optional
+
+_metrics: Dict[str, int] = {
+    "bus_errors": 0,
+    "restarts": 0,
+    "decoding_failures": 0,
+}
+
+_output_file: Optional[str] = None
+_server: Optional[HTTPServer] = None
+
+
+def get_metrics() -> Dict[str, int]:
+    """Return a snapshot of the current metrics."""
+    return dict(_metrics)
+
+
+def reset_metrics() -> None:
+    """Reset all counters to zero."""
+    for key in _metrics:
+        _metrics[key] = 0
+    _write()
+
+
+def set_output_file(path: str | None) -> None:
+    """Write metrics to ``path`` whenever they change."""
+    global _output_file
+    _output_file = path
+    _write()
+
+
+def record_bus_error() -> None:
+    _metrics["bus_errors"] += 1
+    _write()
+
+
+def record_restart() -> None:
+    _metrics["restarts"] += 1
+    _write()
+
+
+def record_decoding_failure() -> None:
+    _metrics["decoding_failures"] += 1
+    _write()
+
+
+def _write() -> None:
+    if _output_file:
+        with open(_output_file, "w", encoding="utf-8") as f:
+            json.dump(_metrics, f)
+
+
+class _MetricsHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # pragma: no cover - trivial
+        payload = json.dumps(_metrics).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    # Suppress default logging
+    def log_message(
+        self, format: str, *args: object
+    ) -> None:  # pragma: no cover - noise
+        return
+
+
+def start_http_server(port: int = 8000) -> HTTPServer:
+    """Start a thread serving metrics via HTTP."""
+    global _server
+    _server = HTTPServer(("", port), _MetricsHandler)
+    thread = threading.Thread(target=_server.serve_forever, daemon=True)
+    thread.start()
+    return _server
+
+
+def stop_http_server() -> None:
+    """Shut down the metrics HTTP server if running."""  # pragma: no cover - trivial
+    global _server
+    if _server:
+        _server.shutdown()
+        _server.server_close()
+        _server = None

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,54 @@
+import json
+import urllib.request
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from metrics import (  # noqa: E402
+    record_bus_error,
+    record_decoding_failure,
+    record_restart,
+    reset_metrics,
+    set_output_file,
+    start_http_server,
+    stop_http_server,
+)
+
+
+def test_metrics_file_and_reset(tmp_path):
+    reset_metrics()
+    stats = tmp_path / "stats.json"
+    set_output_file(str(stats))
+
+    record_bus_error()
+    record_restart()
+    record_decoding_failure()
+
+    data = json.loads(stats.read_text())
+    assert data == {
+        "bus_errors": 1,
+        "restarts": 1,
+        "decoding_failures": 1,
+    }
+
+    reset_metrics()
+    data = json.loads(stats.read_text())
+    assert data == {
+        "bus_errors": 0,
+        "restarts": 0,
+        "decoding_failures": 0,
+    }
+
+
+def test_metrics_http_endpoint():
+    reset_metrics()
+    record_bus_error()
+    server = start_http_server(0)
+    try:
+        port = server.server_port
+        body = urllib.request.urlopen(f"http://localhost:{port}").read().decode()
+        data = json.loads(body)
+        assert data["bus_errors"] == 1
+    finally:
+        stop_http_server()


### PR DESCRIPTION
## Summary
- add metrics module to count bus errors, restarts and decoding failures
- expose metrics via optional JSON file and HTTP endpoint
- instrument CAN monitor and tests to use and reset metrics

## Testing
- `pre-commit run --files src/metrics.py src/can_monitor.py tests/test_can_monitor.py tests/test_transport.py tests/test_metrics.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd83befb083249bb2a2c5f4384baf