### PR TITLE
Improve CAN monitor robustness and transport handling

### DIFF
--- a/src/transport.py
+++ b/src/transport.py
@@ -1,4 +1,5 @@
 """Transport modules for sending serialized frames."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -33,16 +34,22 @@ class Transport(ABC):
 class HTTPTransport(Transport):
     """HTTP POST transport."""
 
-    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> None:
+    def __init__(
+        self, url: str, headers: Optional[Dict[str, str]] = None, **kwargs: Any
+    ) -> None:
         super().__init__(**kwargs)
         self.url = url
         self.headers = headers or {}
 
-    def _send_once(self, payload: str) -> None:  # pragma: no cover - network errors not deterministic
+    def _send_once(
+        self, payload: str
+    ) -> None:  # pragma: no cover - network errors not deterministic
         from urllib import request
 
-        req = request.Request(self.url, data=payload.encode(), headers=self.headers, method="POST")
-        with request.urlopen(req) as resp:
+        req = request.Request(
+            self.url, data=payload.encode(), headers=self.headers, method="POST"
+        )
+        with request.urlopen(req, timeout=5) as resp:
             resp.read()
 
 
@@ -54,7 +61,9 @@ class MQTTTransport(Transport):
         self.topic = topic
         self.hostname = hostname
 
-    def _send_once(self, payload: str) -> None:  # pragma: no cover - depends on external lib
+    def _send_once(
+        self, payload: str
+    ) -> None:  # pragma: no cover - depends on external lib
         try:
             from paho.mqtt import publish
         except Exception as exc:  # ImportError

--- a/tests/test_canbus_setup.py
+++ b/tests/test_canbus_setup.py
@@ -13,5 +13,6 @@ def test_setup_interface_builds_commands():
         "modprobe can",
         "modprobe can_raw",
         "ip link set can0 down",
-        "ip link set can0 up type can bitrate 250000 listen-only on",
+        "ip link set can0 up type can bitrate 250000",
+        "ip link set can0 type can listen-only on",
     ]

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -29,14 +29,9 @@ def log_setup(tmp_path):
     logger = logging.getLogger(f"test_{uuid.uuid4().hex}")
     logger.setLevel(logging.INFO)
     handler = logging.FileHandler(log_file)
+    handler.setFormatter(logging.Formatter("%(message)s"))
     logger.addHandler(handler)
     logger.propagate = False
-
-    def info(msg, *args, **kwargs):
-        formatted = msg.replace("%%", "%") % args
-        logger._log(logging.INFO, formatted, (), **kwargs)
-
-    logger.info = info  # type: ignore[assignment]
 
     try:
         yield logger, log_file


### PR DESCRIPTION
## Summary
- fix logging formats and add extended-ID aware output
- add background queue for non-blocking transport and idle-loop bus-off detection
- harden CAN interface setup and add HTTP timeout

## Testing
- `pre-commit run --files src/can_monitor.py src/canbus/setup.py src/transport.py tests/test_can_monitor.py tests/test_canbus_setup.py tests/test_transport.py`

------
https://chatgpt.com/codex/tasks/task_e_688fdaafc7388324b1ed9c837b4e9863