### PR TITLE
Handle extended CAN IDs in monitor

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -114,6 +114,8 @@ def monitor(
                 time.sleep(0.1)
                 continue
 
+            id_fmt = "%08X" if getattr(msg, "is_extended_id", False) else "%03X"
+
             decoded = None
             if db:
                 try:
@@ -124,14 +126,17 @@ def monitor(
                     )
                 except KeyError:
                     record_decoding_failure()
-                    logger.debug("No DBC entry for id=0x%03X", msg.arbitration_id)
+                    logger.debug(
+                        "No DBC entry for id=0x%s", id_fmt % msg.arbitration_id
+                    )
                 except Exception as exc:  # pragma: no cover - depends on DBC
                     record_decoding_failure()
                     logger.warning(
-                        "Decoding error for id=0x%03X: %s", msg.arbitration_id, exc
+                        "Decoding error for id=0x%s: %s",
+                        id_fmt % msg.arbitration_id,
+                        exc,
                     )
 
-            id_fmt = "%08X" if getattr(msg, "is_extended_id", False) else "%03X"
             logger.info(
                 "id=0x%s raw=%s decoded=%s",
                 id_fmt % msg.arbitration_id,

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -74,8 +74,10 @@ def test_monitor_decodes_extended_ids(bitrate, log_setup):
 
     contents = log_file.read_text()
     expected_decoded = db.decode_message(msg.arbitration_id, msg.data)
+    fmt = "08X" if msg.is_extended_id else "03X"
     expected = (
-        f"id=0x{msg.arbitration_id:08X} raw={msg.data.hex()} decoded={expected_decoded}"
+        f"id=0x{msg.arbitration_id:{fmt}} raw={msg.data.hex()} "
+        f"decoded={expected_decoded}"
     )
     assert expected in contents
 
@@ -130,7 +132,8 @@ def test_monitor_handles_missing_dbc(log_setup):
             monitor(bus, db, logger)
 
     contents = log_file.read_text()
-    expected = f"id=0x{msg.arbitration_id:08X} raw={msg.data.hex()} decoded=None"
+    fmt = "08X" if msg.is_extended_id else "03X"
+    expected = f"id=0x{msg.arbitration_id:{fmt}} raw={msg.data.hex()} decoded=None"
     assert expected in contents
 
 
@@ -159,7 +162,8 @@ def test_monitor_handles_malformed_frame(log_setup):
             monitor(bus, db, logger)
 
     contents = log_file.read_text()
-    expected = f"id=0x{msg.arbitration_id:08X} raw={msg.data.hex()} decoded=None"
+    fmt = "08X" if msg.is_extended_id else "03X"
+    expected = f"id=0x{msg.arbitration_id:{fmt}} raw={msg.data.hex()} decoded=None"
     assert expected in contents
     assert get_metrics()["decoding_failures"] == 1
 


### PR DESCRIPTION
## Summary
- Detect extended CAN IDs and format them as 8-digit hex when logging; use 3-digit format for standard IDs
- Update tests to expect the new ID formatting

## Testing
- `pre-commit run --files src/can_monitor.py tests/test_can_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_688fdcd799848324ac8ee193ef9fdbb7