### PR TITLE
Add BLF decoding utility and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,25 @@ These diagrams illustrate a typical wiring sequence for a common MCP2515 module.
 ### Step 3 – Connect to Vehicle
 
 ![Step 3: Connect to Vehicle](docs/mcp2515_step3_can.svg)
+
+## Dependencies
+
+The utilities and tests rely on a few Python packages:
+
+- [`python-can`](https://python-can.readthedocs.io/)
+- [`cantools`](https://cantools.readthedocs.io/)
+- [`paho-mqtt`](https://www.eclipse.org/paho/)
+
+Install them with `pip install -r requirements.txt`.
+
+## BLF Log Decoding
+
+A small helper script, `blf_decoder.py`, can decode Vector BLF log files
+using the bundled `OBD.dbc` database:
+
+```bash
+python -m blf_decoder PV11-yadwad_0004465_20250102_012231.blf
+```
+
+Pass `--dbc` to supply an alternative DBC file.  Each decoded frame is
+printed as `id`, raw hex payload and the parsed signal dictionary.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-can
+cantools
+paho-mqtt

--- a/src/blf_decoder.py
+++ b/src/blf_decoder.py
@@ -1,0 +1,62 @@
+"""Decode BLF log files using a DBC database.
+
+This helper module provides a small API and command-line interface for
+converting Vector BLF log files into decoded CAN frames using the project's
+``OBD.dbc`` database.  It is intentionally lightweight so it can be used
+in scripts or during testing.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterator, Tuple, Optional, Any
+
+try:  # pragma: no cover - import error handled in runtime environments
+    import can
+    import cantools
+except Exception as exc:  # pragma: no cover - dependency resolution
+    raise RuntimeError("cantools and python-can are required for BLF decoding") from exc
+
+
+def decode_blf(
+    blf_path: str, dbc_path: str
+) -> Iterator[Tuple["can.Message", Optional[Any]]]:
+    """Iterate over messages in ``blf_path`` decoding with ``dbc_path``.
+
+    Parameters
+    ----------
+    blf_path:
+        Path to the BLF log file.
+    dbc_path:
+        Path to the DBC database used for decoding.
+    """
+    db = cantools.database.load_file(dbc_path)
+    reader = can.BLFReader(blf_path)
+    for msg in reader:
+        try:
+            decoded = db.decode_message(msg.arbitration_id, msg.data)
+        except Exception:
+            decoded = None
+        yield msg, decoded
+
+
+def main(argv: Optional[list[str]] = None) -> int:  # pragma: no cover - CLI glue
+    parser = argparse.ArgumentParser(description="Decode BLF log using OBD DBC")
+    parser.add_argument("blf", help="Path to BLF log file")
+    parser.add_argument(
+        "--dbc",
+        default=str(__file__).replace("blf_decoder.py", "OBD.dbc"),
+        help="Path to DBC file (default: OBD.dbc in source directory)",
+    )
+    args = parser.parse_args(argv)
+
+    for msg, decoded in decode_blf(args.blf, args.dbc):
+        fmt = "08X" if getattr(msg, "is_extended_id", False) else "03X"
+        print(
+            f"id=0x{msg.arbitration_id:{fmt}} data={msg.data.hex()} decoded={decoded}"
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/test_blf_decoder.py
+++ b/tests/test_blf_decoder.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from blf_decoder import decode_blf  # noqa: E402
+
+
+def test_decode_blf_first_frame():
+    blf_path = os.path.join(
+        os.path.dirname(__file__), "..", "PV11-yadwad_0004465_20250102_012231.blf"
+    )
+    dbc_path = os.path.join(os.path.dirname(__file__), "..", "src", "OBD.dbc")
+    iterator = decode_blf(blf_path, dbc_path)
+    msg, decoded = next(iterator)
+    assert msg.arbitration_id == 0x0C08A7F0
+    assert isinstance(decoded, dict)
+    assert decoded.get("MCU_TrqEst") == 0.0


### PR DESCRIPTION
## Summary
- document required CAN dependencies and add a helper tool for decoding BLF logs via OBD.dbc
- provide requirements.txt for python-can, cantools and MQTT support
- add tests exercising BLF decoding on the sample log file

## Testing
- `pre-commit run --files src/blf_decoder.py tests/test_blf_decoder.py README.md requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe3c06e888324b54e7f88421cbe00