### PR TITLE
feat: add raw CAN logging option

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -79,6 +79,7 @@ Additional options:
 - `--log can.log` – change log file path.
 - `--log-level DEBUG` – increase verbosity.
 - `--listen-only` – avoid transmitting frames.
+- `--print-raw` – include raw CAN payloads in the log.
 - `--config settings.json` – load options from a JSON file (currently only `log_level`).
 
 Example `settings.json`:
@@ -89,8 +90,10 @@ Example `settings.json`:
 }
 ```
 
-The log records raw and decoded frames.  When decoding fails, the log includes a
-message and the metrics counter `decoding_failures` is incremented.
+When `--print-raw` is supplied, the log records the raw CAN payload for each
+frame and, when decoding succeeds, the decoded signal dictionary.  When decoding
+fails, the log includes a message and the metrics counter `decoding_failures` is
+incremented.
 
 **Potential issues**
 - `python-can is required but not installed`: install dependencies with pip.


### PR DESCRIPTION
## Summary
- add `--print-raw` option to can_monitor CLI
- log raw CAN payloads and decoded signals when the flag is used
- cover new behavior with tests and documentation

## Testing
- `pre-commit run --files src/can_monitor.py docs/GETTING_STARTED.md tests/test_can_monitor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e861b3b483248bf5a30bc36bf428