### PR TITLE
feat: add configurable startup CAN patches

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -80,13 +80,22 @@ Additional options:
 - `--log-level DEBUG` – increase verbosity.
 - `--listen-only` – avoid transmitting frames.
 - `--print-raw` – include raw CAN payloads in the log.
-- `--config settings.json` – load options from a JSON file (currently only `log_level`).
+- `--config settings.json` – load options from a JSON file (`log_level`, startup `patches`, etc.).
 
 Example `settings.json`:
 
 ```json
 {
-  "log_level": "DEBUG"
+  "log_level": "DEBUG",
+  "patches": {
+    "vcu_security_level1": {
+      "can_id": 2016,
+      "payload": "06 27 01 01 01 00 00 00",
+      "response_id": 2024,
+      "timeout_ms": 500,
+      "retries": 2
+    }
+  }
 }
 ```
 

--- a/vcu_security_patch.json
+++ b/vcu_security_patch.json
@@ -1,0 +1,12 @@
+{
+  "log_level": "INFO",
+  "patches": {
+    "vcu_security_level1": {
+      "can_id": 2016,
+      "payload": "06 27 01 01 01 00 00 00",
+      "response_id": 2024,
+      "timeout_ms": 500,
+      "retries": 2
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow `can_monitor.py` to send one-shot CAN frames defined in config
- document new `patches` config option and provide example VCU security unlock file
- add tests for configurable patch routine

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68945e355c548324ac892d50e5d0cfc8