### PR TITLE
Implement seed-based UDS security access

### DIFF
--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -76,5 +76,7 @@ def test_session_and_security(monkeypatch):
     monkeypatch.setattr(bus, "recv", fake_recv)
 
     assert client.change_session(3)
-    assert client.security_access(1, b"\x00\x00")
+    assert client.security_access(1)
     assert len(sent) == 3
+    # verify key derived from seed AA BB -> 55 44 (bitwise inversion)
+    assert sent[2].data[:5] == bytes([0x04, 0x27, 0x02, 0x55, 0x44])


### PR DESCRIPTION
## Summary
- derive security access keys from ECU seeds using a default inversion algorithm
- expose optional key derivation hook and use it when `security_access` is called
- initialize UDS session/security during monitor startup based on configuration
- update tests to validate seed-based key derivation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895c62ad2288324b895df1e6c9dfa4f