### PR TITLE
Add ISO-TP primitive callbacks to UDSClient

### DIFF
--- a/src/isotp_primitives.py
+++ b/src/isotp_primitives.py
@@ -1,0 +1,36 @@
+"""ISO-TP service primitive callbacks.
+
+This module defines the :class:`TDataPrimitive` container which groups
+callbacks corresponding to ISO-TP service primitives.  Applications can
+provide callables to observe or modify transport-layer events.
+
+The primitives include:
+
+``req``
+    Invoked when a transport layer request is made.
+``con``
+    Confirmation callback triggered after transmission completes.  It
+    receives ``(success, error)`` where ``success`` is ``True`` when the
+    request finished without raising and ``error`` contains the exception
+    instance on failure.
+``ind``
+    Indication callback fired when a complete response payload has been
+    reassembled.
+``som_ind``
+    Optional "start-of-message" indication fired when the first frame of a
+    multi-frame response is received.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+@dataclass
+class TDataPrimitive:
+    """Container for ISO-TP transport service callbacks."""
+
+    req: Optional[Callable[[int, bytes], None]] = None
+    ind: Optional[Callable[[bytes], None]] = None
+    con: Optional[Callable[[bool, Exception | None], None]] = None
+    som_ind: Optional[Callable[[], None]] = None


### PR DESCRIPTION
## Summary
- Introduce `TDataPrimitive` container for ISO-TP service callbacks
- Hook `UDSClient` into the primitive callbacks for request, confirm, and indication phases
- Add tests ensuring ISO-TP primitives fire on request/response

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b8acaca48324aaf3034529e5d93f