### PR TITLE
Add cumulative ISO-TP timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,8 @@ are logged with their description and severity, and any critical codes
 emit an alert in the log output.
 
 A sample configuration is bundled as `uds_config.json` for quick access.
+
+The low level ``UDSClient`` helper used by the monitor also exposes a
+configurable timeout.  The ``timeout`` argument of ``send`` and ``request`` may
+be either a single float or a ``(N_Bs, N_Cr)`` tuple to independently limit how
+long the client waits for Flow Control frames and for response data.


### PR DESCRIPTION
## Summary
- track cumulative wait time for flow control frames in `UDSClient.send`
- allow separate `(N_Bs, N_Cr)` timeout configuration for send/request
- document new timeout behavior and add tests for overall timeout handling

## Testing
- `pre-commit run --files src/uds.py README.md tests/test_uds_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897c9c56ea0832492bba9d2fe819d85