### PR TITLE
Warn or error on ISO-TP receive reset

### DIFF
--- a/src/uds.py
+++ b/src/uds.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Callable
 
@@ -60,6 +61,12 @@ class UDSClient:
     max_rx_size: int, optional
         Maximum number of bytes allowed when reassembling multi-frame
         responses.  When ``None`` no limit is enforced.
+    on_reset: callable, optional
+        Function invoked when reception is reset due to an unexpected
+        start-of-frame.
+    error_on_reset: bool, optional
+        When ``True``, an :class:`ISOTransportError` is raised instead of
+        logging a warning when a reset occurs.
     """
 
     def __init__(
@@ -77,6 +84,8 @@ class UDSClient:
         address_extension: "int | None" = None,
         t_data: "TDataPrimitive | None" = None,
         max_rx_size: "int | None" = None,
+        on_reset: "Callable[[], None] | None" = None,
+        error_on_reset: bool = False,
     ) -> None:
         self.bus = bus
         self.req_id = req_id
@@ -90,6 +99,8 @@ class UDSClient:
         self.address_extension = address_extension
         self.t_data = t_data
         self.max_rx_size = max_rx_size
+        self.on_reset = on_reset
+        self.error_on_reset = error_on_reset
         self._rx_fc_status = 0
 
         if self.source_address is not None and self.target_address is not None:
@@ -323,6 +334,18 @@ class UDSClient:
                     continue
                 data = data[1:]
             frame_type = data[0] >> 4
+            if state["expected"] > 0 and frame_type in (0x0, 0x1):
+                state["expected"] = 0
+                state["payload"] = bytearray()
+                if self.on_reset:
+                    self.on_reset()
+                if self.error_on_reset:
+                    raise ISOTransportError(
+                        "Unexpected start-of-frame during reception"
+                    )
+                logging.warning(
+                    "ISO-TP reception reset due to unexpected start-of-frame"
+                )
             if frame_type == 0x0:  # single
                 length = data[0] & 0x0F
                 payload = data[1 : 1 + length]  # noqa: E203
@@ -366,9 +389,19 @@ class UDSClient:
                     self._send_fc(status=self._rx_fc_status)
                     state["bs"] = 0
                 continue
-            # new SF/FF while in progress -> reset
-            state["expected"] = 0
-            state["payload"] = bytearray()
+            if state["expected"] > 0:
+                state["expected"] = 0
+                state["payload"] = bytearray()
+                if self.on_reset:
+                    self.on_reset()
+                if self.error_on_reset:
+                    raise ISOTransportError(
+                        "Unexpected start-of-frame during reception"
+                    )
+                logging.warning(
+                    "ISO-TP reception reset due to unexpected start-of-frame"
+                )
+                continue
 
     # ------------------------------------------------------------------
     def request(

--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -1,4 +1,5 @@
 import time
+import logging
 import can
 import pytest
 
@@ -310,6 +311,68 @@ def test_receive_overflow(monkeypatch):
 
     fc_frames = [m for m in sent if (m.data[0] >> 4) == 0x3]
     assert fc_frames and fc_frames[0].data[0] == 0x32
+
+
+def test_receive_reset_warns_and_calls_hook(monkeypatch, caplog):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    hooks: list[str] = []
+    client = UDSClient(bus, 0x7E0, 0x7E8, on_reset=lambda: hooks.append("reset"))
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
+
+    ff1 = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x10, 0x0A, 0, 1, 2, 3, 4, 5]),
+        is_extended_id=False,
+    )
+    sf = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x02, 0x62, 0x00, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    responses = [ff1, sf]
+    monkeypatch.setattr(bus, "recv", lambda timeout: responses.pop(0) if responses else None)
+
+    with caplog.at_level(logging.WARNING):
+        payload = client.receive()
+
+    assert payload[:2] == bytes([0x62, 0x00])
+    assert hooks == ["reset"]
+    assert any("unexpected start-of-frame" in r.message for r in caplog.records)
+
+
+def test_receive_reset_raises_with_error_on_reset(monkeypatch):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    hooks: list[str] = []
+    client = UDSClient(
+        bus,
+        0x7E0,
+        0x7E8,
+        on_reset=lambda: hooks.append("reset"),
+        error_on_reset=True,
+    )
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
+
+    ff1 = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x10, 0x0A, 0, 1, 2, 3, 4, 5]),
+        is_extended_id=False,
+    )
+    ff2 = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x10, 0x0A, 0xAA, 0xBB, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    responses = [ff1, ff2]
+    monkeypatch.setattr(bus, "recv", lambda timeout: responses.pop(0) if responses else None)
+
+    with pytest.raises(ISOTransportError, match="Unexpected start-of-frame"):
+        client.receive()
+
+    assert hooks == ["reset"]
 
 
 def test_request_tuple_timeouts(monkeypatch):


### PR DESCRIPTION
## Summary
- allow UDSClient to expose an on_reset callback and optional exception on unexpected start-of-frame
- log a warning or raise ISOTransportError when receive resets unexpectedly
- cover reset warning and exception behaviors with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897cfa063088324b001c90546c679c4