### PR TITLE
Validate UDS payload length

### DIFF
--- a/src/uds.py
+++ b/src/uds.py
@@ -134,6 +134,8 @@ class UDSClient:
             Consecutive Frame timeout (``N_Cr``).  Default ``1.0`` seconds.
         """
         payload = bytes([service]) + data
+        if len(payload) > 0xFFF:
+            raise ISOTransportError("Payload too large")
         if isinstance(timeout, tuple):
             fc_timeout, send_timeout = timeout
         else:

--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -91,6 +91,21 @@ def test_send_cumulative_fc_timeout(monkeypatch):
         client.send(0x22, data, timeout=1.0)
 
 
+def test_send_rejects_overly_large_payload(monkeypatch):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    client = UDSClient(bus, 0x7E0, 0x7E8)
+
+    sent = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+
+    with pytest.raises(ISOTransportError, match="Payload too large"):
+        client.send(0x22, bytes(0x1000))
+
+    assert not sent
+
+
 def test_session_and_security(monkeypatch):
     bus = can.interface.Bus(
         bustype="virtual", bitrate=500000, receive_own_messages=True
@@ -332,7 +347,9 @@ def test_receive_reset_warns_and_calls_hook(monkeypatch, caplog):
         is_extended_id=False,
     )
     responses = [ff1, sf]
-    monkeypatch.setattr(bus, "recv", lambda timeout: responses.pop(0) if responses else None)
+    monkeypatch.setattr(
+        bus, "recv", lambda timeout: responses.pop(0) if responses else None
+    )
 
     with caplog.at_level(logging.WARNING):
         payload = client.receive()
@@ -367,7 +384,9 @@ def test_receive_reset_raises_with_error_on_reset(monkeypatch):
         is_extended_id=False,
     )
     responses = [ff1, ff2]
-    monkeypatch.setattr(bus, "recv", lambda timeout: responses.pop(0) if responses else None)
+    monkeypatch.setattr(
+        bus, "recv", lambda timeout: responses.pop(0) if responses else None
+    )
 
     with pytest.raises(ISOTransportError, match="Unexpected start-of-frame"):
         client.receive()


### PR DESCRIPTION
## Summary
- raise ISOTransportError when UDS payload exceeds 4KB
- test UDSClient.send rejects overly large payloads

## Testing
- `pre-commit run --files src/uds.py tests/test_uds_client.py`
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_6897d24849a8832499485ec4c01c39e1