### PR TITLE
Add UDS flow control edge case tests

### DIFF
--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -575,3 +575,111 @@ def test_uds_fc_address_extension(log_setup):
     assert sent[0].data[0] == 0x99
     assert sent[0].data[1] == 0x30
     assert not sent[0].is_extended_id
+
+
+def test_uds_dtc_alert_extended_id(log_setup):
+    logger, log_file = log_setup
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+
+    with open(Path(__file__).resolve().parents[1] / "uds_config.json") as f:
+        uds_cfg = json.load(f)["uds"]
+    uds_cfg.update(
+        {
+            "ecu_request_id": 0x18DA10F1,
+            "ecu_response_id": 0x18DAF110,
+            "flow_control": {"block_size": 0, "st_min_ms": 0},
+        }
+    )
+
+    payload = bytes([0x59, 0x02, 0x02, 0x20, 0xF9, 0x00, 0x40, 0x05, 0x8D, 0x00, 0x40])
+    length = len(payload)
+    ff = can.Message(
+        arbitration_id=uds_cfg["ecu_response_id"],
+        data=bytes([0x10 | ((length >> 8) & 0x0F), length & 0xFF])
+        + payload[:6]
+        + bytes(8 - 2 - 6),
+        is_extended_id=True,
+    )
+    cf = can.Message(
+        arbitration_id=uds_cfg["ecu_response_id"],
+        data=bytes([0x21]) + payload[6:13] + bytes(7 - len(payload[6:13])),
+        is_extended_id=True,
+    )
+    frames = [ff, cf]
+
+    def fake_recv(timeout=1.0):
+        if frames:
+            return frames.pop(0)
+        raise can.CanError("stop")
+
+    sent: list[can.Message] = []
+
+    def fake_send(msg, timeout=None):  # pragma: no cover - capture only
+        sent.append(msg)
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv), patch.object(
+            bus, "send", side_effect=fake_send
+        ):
+            monitor(bus, None, logger, uds_config=uds_cfg)
+
+    contents = log_file.read_text()
+    assert "DTC P20F9" in contents
+    assert sent and sent[0].is_extended_id
+    assert sent[0].arbitration_id == uds_cfg["ecu_request_id"]
+
+
+def test_uds_dtc_alert_address_extension(log_setup):
+    logger, log_file = log_setup
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+
+    with open(Path(__file__).resolve().parents[1] / "uds_config.json") as f:
+        uds_cfg = json.load(f)["uds"]
+    uds_cfg.update(
+        {
+            "flow_control": {"block_size": 0, "st_min_ms": 0},
+            "address_extension": 0x99,
+        }
+    )
+
+    payload = bytes([0x59, 0x02, 0x02, 0x20, 0xF9, 0x00, 0x40, 0x05, 0x8D, 0x00, 0x40])
+    length = len(payload)
+    ff = can.Message(
+        arbitration_id=uds_cfg["ecu_response_id"],
+        data=bytes([0x99, 0x10 | ((length >> 8) & 0x0F), length & 0xFF])
+        + payload[:5]
+        + bytes(8 - 3 - 5),
+        is_extended_id=False,
+    )
+    cf = can.Message(
+        arbitration_id=uds_cfg["ecu_response_id"],
+        data=bytes([0x99, 0x21]) + payload[5:11] + bytes(6 - len(payload[5:11])),
+        is_extended_id=False,
+    )
+    frames = [ff, cf]
+
+    def fake_recv(timeout=1.0):
+        if frames:
+            return frames.pop(0)
+        raise can.CanError("stop")
+
+    sent: list[can.Message] = []
+
+    def fake_send(msg, timeout=None):  # pragma: no cover - capture only
+        sent.append(msg)
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv), patch.object(
+            bus, "send", side_effect=fake_send
+        ):
+            monitor(bus, None, logger, uds_config=uds_cfg)
+
+    contents = log_file.read_text()
+    assert "DTC P20F9" in contents
+    assert sent and sent[0].data[0] == 0x99
+    assert not sent[0].is_extended_id
+

--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -514,3 +514,118 @@ def test_request_thread_locking(monkeypatch):
         client.request(0x10, b"\x03")
     release.set()
     t.join()
+
+
+def test_send_wait_then_cts(monkeypatch, caplog):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    test_logger = logging.getLogger("uds_wait")
+    test_logger.setLevel(logging.DEBUG)
+    client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger)
+
+    sent: list[can.Message] = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+
+    fc_wait = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x31, 0, 0, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    fc_cts = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x30, 0, 0, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+
+    calls = {"count": 0}
+
+    def fake_recv(timeout):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            assert len(sent) == 1
+            return fc_wait
+        if calls["count"] == 2:
+            assert len(sent) == 1
+            return fc_cts
+        return None
+
+    monkeypatch.setattr(bus, "recv", fake_recv)
+
+    with caplog.at_level(logging.DEBUG, logger="uds_wait"):
+        client.send(0x22, bytes(range(10)))
+
+    assert len(sent) == 2
+    assert sent[1].data[0] == 0x21
+    assert any("Flow Control WAIT received" in r.message for r in caplog.records)
+
+
+def test_send_wait_timeout(monkeypatch, caplog):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    test_logger = logging.getLogger("uds_wait_timeout")
+    test_logger.setLevel(logging.DEBUG)
+    client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger)
+
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
+
+    fc_wait = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x31, 0, 0, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+
+    events = [(0.6, fc_wait)]
+    now = [0.0]
+
+    def fake_monotonic():
+        return now[0]
+
+    def fake_recv(timeout):
+        if events:
+            delay, msg = events[0]
+            if delay > timeout:
+                now[0] += timeout
+                events[0] = (delay - timeout, msg)
+                return None
+            now[0] += delay
+            events.pop(0)
+            return msg
+        now[0] += timeout
+        return None
+
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(bus, "recv", fake_recv)
+
+    with caplog.at_level(logging.DEBUG, logger="uds_wait_timeout"):
+        with pytest.raises(ISOTransportError, match="No Flow Control frame received"):
+            client.send(0x22, bytes(range(10)), timeout=1.0)
+
+    assert any("Flow Control WAIT received" in r.message for r in caplog.records)
+    assert any("No Flow Control frame received" in r.message for r in caplog.records)
+
+
+def test_send_flow_control_overflow(monkeypatch, caplog):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    test_logger = logging.getLogger("uds_overflow")
+    test_logger.setLevel(logging.DEBUG)
+    client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger)
+
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
+
+    fc_overflow = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x32, 0, 0, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    monkeypatch.setattr(bus, "recv", lambda timeout: fc_overflow)
+
+    with caplog.at_level(logging.DEBUG, logger="uds_overflow"):
+        with pytest.raises(ISOTransportError, match="Flow control overflow"):
+            client.send(0x22, bytes(range(10)))
+
+    assert any("Flow control overflow" in r.message for r in caplog.records)
+


### PR DESCRIPTION
## Summary
- cover WAIT and overflow handling in UDSClient with timeout checks
- exercise CAN monitor with extended IDs and address extension for UDS DTC alerts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897d8daa2188324b827c9d9cdf0f600