### PR TITLE
feat: add pluggable security algorithm

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -116,7 +116,9 @@ Example `vcu_security_patch.json`:
 ```
 
 A sample UDS configuration is provided in `uds_config.json` and can be passed
-with `--config` to enable diagnostic trouble code decoding.
+with `--config` to enable diagnostic trouble code decoding.  The security block
+supports an optional ``algorithm`` entry referencing a callable or
+``module:attr`` string used to derive the access key.
 
 To troubleshoot ISO-TP segmentation, ``UDSClient`` supports standard Python
 logging. Create a logger and pass it to the client to view debug output:

--- a/docs/VCU_UDS_COMMUNICATION.md
+++ b/docs/VCU_UDS_COMMUNICATION.md
@@ -52,9 +52,10 @@ specified number of times.  Exhausting retries aborts the UDS start‑up.
 ### Security Access
 After the session switch the client requests security level 1.  The first
 request (`06 27 01 01 01 00 00 00`) asks the VCU for a seed.  The client then
-computes the corresponding key and submits it in a follow‑up `0x27` request.  By
-default the key is the bit‑wise inversion of the seed unless a custom algorithm
-is provided.
+computes the corresponding key and submits it in a follow‑up `0x27` request.  The
+algorithm used to derive the key is pluggable: by default the seed bytes are
+bit‑wise inverted, but a custom function or ``module:attr`` string can be
+supplied in configuration under ``security.algorithm``.
 
 ```json
 {
@@ -69,7 +70,9 @@ is provided.
 ```
 
 If the VCU does not answer with a positive response (`0x67`) or the computed key
-is rejected, `security_access` returns `False` and diagnostic polling stops.
+is rejected, :meth:`security_access` raises :class:`ISOTransportError` with the
+negative response code, allowing the caller to surface a detailed error and
+abort diagnostic polling.
 
 ### Multi‑Frame Flow Control
 

--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -29,7 +29,7 @@ from metrics import (
     record_restart,
     reset_metrics,
 )
-from uds import UDSClient
+from uds import ISOTransportError, UDSClient
 
 try:
     import can
@@ -606,6 +606,11 @@ def main(argv: Optional[list[str]] = None) -> int:
                     apply_patches(bus, config["patches"])
                 if uds_cfg:
                     try:
+                        key_algo_spec = (
+                            uds_cfg.get("security", {}).get("algorithm")
+                            if uds_cfg
+                            else None
+                        )
                         client = UDSClient(
                             bus,
                             uds_cfg["ecu_request_id"],
@@ -617,6 +622,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                             rx_st_min=uds_cfg.get("flow_control", {}).get(
                                 "st_min_ms", 0
                             ),
+                            key_algo=key_algo_spec,
                             source_address=uds_cfg.get("source_address"),
                             target_address=uds_cfg.get("target_address"),
                             address_extension=uds_cfg.get("address_extension"),
@@ -636,10 +642,15 @@ def main(argv: Optional[list[str]] = None) -> int:
                                 if isinstance(key_hex, str)
                                 else None
                             )
-                            if client.security_access(level, key):
-                                logger.info("UDS security level %s unlocked", level)
-                            else:
-                                logger.warning("UDS security level %s denied", level)
+                            try:
+                                client.security_access(level, key)
+                                logger.info(
+                                    "UDS security level %s unlocked", level
+                                )
+                            except ISOTransportError as exc:
+                                logger.warning(
+                                    "UDS security level %s denied: %s", level, exc
+                                )
                     except Exception as exc:  # pragma: no cover - best effort
                         logger.warning("UDS initialisation failed: %s", exc)
                 if db is None and not fallback_dbs:

--- a/src/uds.py
+++ b/src/uds.py
@@ -9,6 +9,7 @@ messaging methods must be serialized externally or they will raise a
 
 from __future__ import annotations
 
+import importlib
 import logging
 import threading
 import time
@@ -22,6 +23,31 @@ except ImportError:  # pragma: no cover - optional dependency
 from isotp_primitives import TDataPrimitive
 
 LOGGER = logging.getLogger(__name__)
+
+
+def default_key_algo(seed: bytes) -> bytes:
+    """Fallback key algorithm performing a bitwise inversion."""
+
+    return bytes((b ^ 0xFF) & 0xFF for b in seed)
+
+
+def _load_key_algo(
+    spec: "Callable[[bytes], bytes] | str | None",
+) -> "Callable[[bytes], bytes]":
+    """Resolve a key algorithm from a callable or ``module:attr`` string."""
+
+    if spec is None:
+        return default_key_algo
+    if callable(spec):
+        return spec
+    if isinstance(spec, str):
+        module_name, _, attr = spec.partition(":")
+        module = importlib.import_module(module_name)
+        algo = getattr(module, attr) if attr else module
+        if callable(algo):
+            return algo  # type: ignore[arg-type]
+        raise TypeError("Security key algorithm is not callable")
+    raise TypeError("Invalid key algorithm specification")
 
 
 class ISOTransportError(RuntimeError):
@@ -59,9 +85,11 @@ class UDSClient:
     rx_st_min: int, optional
         Minimum separation time in milliseconds to advertise in flow
         control frames.
-        key_algo: callable, optional
+        key_algo: callable or ``module:attr`` string, optional
         Function applied to the received seed to generate the security
-        access key.  When not provided a simple bitwise inversion is used.
+        access key. When ``None`` a default inversion-based algorithm is
+        used.  If a string is supplied it is treated as ``module:attr`` and
+        imported dynamically, allowing pluggable algorithms.
     source_address: int, optional
         8-bit source address used for normal-fixed addressing.  When both
         ``source_address`` and ``target_address`` are provided the
@@ -94,7 +122,7 @@ class UDSClient:
         is_extended_id: bool = False,
         rx_block_size: int = 0,
         rx_st_min: int = 0,
-        key_algo: "Callable[[bytes], bytes] | None" = None,
+        key_algo: "Callable[[bytes], bytes] | str | None" = None,
         source_address: "int | None" = None,
         target_address: "int | None" = None,
         address_extension: "int | None" = None,
@@ -110,7 +138,7 @@ class UDSClient:
         self.is_extended_id = is_extended_id
         self.rx_block_size = rx_block_size
         self.rx_st_min = rx_st_min
-        self._key_algo = key_algo
+        self._key_algo = _load_key_algo(key_algo)
         self.source_address = source_address
         self.target_address = target_address
         self.address_extension = address_extension
@@ -525,35 +553,47 @@ class UDSClient:
         rsp = self.request(0x10, bytes([session]), timeout)
         return rsp[:2] == bytes([0x50, session])
 
-    def _default_key_algo(self, seed: bytes) -> bytes:
-        """Generate a key from a seed using a basic bitwise inversion.
-
-        This simple algorithm flips all bits of the seed.  Real-world ECUs
-        use proprietary algorithms; this serves as a deterministic example
-        for testing and demonstration purposes.
-        """
-
-        return bytes((b ^ 0xFF) & 0xFF for b in seed)
-
     def security_access(
         self, level: int, key: "bytes | None" = None, timeout: float = 1.0
     ) -> bool:
         """Request security access at ``level``.
 
         If ``key`` is ``None`` the key is derived from the ECU-provided seed
-        using ``key_algo`` passed at construction time or a default
-        inversion-based algorithm.
+        using ``key_algo`` specified at construction or via configuration.
+        ``key_algo`` may be a callable or a ``module:attr`` string which is
+        imported dynamically.
+
+        Raises
+        ------
+        ISOTransportError
+            If a negative response is received or the response format is
+            unexpected.
         """
 
         rsp = self.request(0x27, bytes([level * 2 - 1]), timeout)
-        if not rsp or rsp[0] != 0x67:
-            return False
+        if len(rsp) < 2:
+            raise ISOTransportError("Invalid seed response")
+        if rsp[0] == 0x7F:
+            code = rsp[2] if len(rsp) > 2 else 0
+            raise ISOTransportError(
+                f"Security seed request denied (NRC 0x{code:02X})"
+            )
+        if rsp[0] != 0x67 or rsp[1] != level * 2 - 1:
+            raise ISOTransportError("Unexpected seed response")
         seed = rsp[2:]
         if key is None:
-            algo = self._key_algo or self._default_key_algo
-            key = algo(seed)
+            key = self._key_algo(seed)
         rsp2 = self.request(0x27, bytes([level * 2]) + key, timeout)
-        return rsp2[:2] == bytes([0x67, level * 2])
+        if len(rsp2) < 2:
+            raise ISOTransportError("Invalid key response")
+        if rsp2[0] == 0x7F:
+            code = rsp2[2] if len(rsp2) > 2 else 0
+            raise ISOTransportError(
+                f"Security access denied (NRC 0x{code:02X})"
+            )
+        if rsp2[:2] != bytes([0x67, level * 2]):
+            raise ISOTransportError("Unexpected key response")
+        return True
 
     def read_dtc_by_status_mask(self, mask: int = 0xFF, timeout: float = 1.0) -> bytes:
         return self.request(0x19, bytes([0x02, mask]), timeout)

--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -18,7 +18,7 @@ def test_send_segments_respects_flow_control(monkeypatch):
     bus = can.interface.Bus(
         bustype="virtual", bitrate=500000, receive_own_messages=True
     )
-    client = UDSClient(bus, 0x7E0, 0x7E8)
+    client = UDSClient(bus, 0x7E0, 0x7E8, key_algo="uds:default_key_algo")
 
     sent = []
 
@@ -148,6 +148,48 @@ def test_session_and_security(monkeypatch):
     assert len(sent) == 3
     # verify key derived from seed AA BB -> 55 44 (bitwise inversion)
     assert sent[2].data[:5] == bytes([0x04, 0x27, 0x02, 0x55, 0x44])
+
+
+def test_security_access_invalid_key(monkeypatch):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    client = UDSClient(bus, 0x7E0, 0x7E8)
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
+
+    resp_seed = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x04, 0x67, 0x01, 0xAA, 0xBB, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    resp_neg = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x03, 0x7F, 0x27, 0x35, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    responses = [resp_seed, resp_neg]
+    monkeypatch.setattr(bus, "recv", lambda timeout: responses.pop(0))
+
+    with pytest.raises(ISOTransportError, match="0x35"):
+        client.security_access(1, b"\x00\x00")
+
+
+def test_security_access_negative_response(monkeypatch):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    client = UDSClient(bus, 0x7E0, 0x7E8)
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
+
+    resp_neg = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x03, 0x7F, 0x27, 0x22, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    monkeypatch.setattr(bus, "recv", lambda timeout: resp_neg)
+
+    with pytest.raises(ISOTransportError, match="0x22"):
+        client.security_access(1, b"\x00\x00")
 
 
 def test_extended_addressing(monkeypatch):

--- a/uds_config.json
+++ b/uds_config.json
@@ -16,7 +16,7 @@
     "target_address": 16,
     "address_extension": null,
     "session": 3,
-    "security": { "level": 1, "key": null },
+    "security": { "level": 1, "key": null, "algorithm": null },
     "flow_control": { "block_size": 1, "st_min_ms": 1 },
     "dtcs": {
       "P058D": {


### PR DESCRIPTION
## Summary
- allow UDS client to load pluggable security key algorithms via callable or `module:attr` string
- validate security access responses with detailed errors and variable seed/key sizes
- document security algorithm configuration and add tests for valid/invalid/negative access

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999db3768c832497e2f8bfaf9619ca