### PR TITLE
Add wft_max handling for ISO-TP WAIT frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ client = UDSClient(bus, 0x7E0, 0x7E8, rx_block_size=1, rx_st_min=20)
 
 # Protect against oversized responses
 client = UDSClient(bus, 0x7E0, 0x7E8, max_rx_size=1024)
+
+# Permit a single Flow Control WAIT before aborting
+client = UDSClient(bus, 0x7E0, 0x7E8, wft_max=1)
 ```
 
 Equivalent settings may be supplied in the JSON configuration:

--- a/src/uds.py
+++ b/src/uds.py
@@ -85,6 +85,9 @@ class UDSClient:
     rx_st_min: int, optional
         Minimum separation time in milliseconds to advertise in flow
         control frames.
+    wft_max: int, optional
+        Maximum number of consecutive Flow Control WAIT frames permitted
+        before aborting.  Default ``0`` per ISO-15765-2.
         key_algo: callable or ``module:attr`` string, optional
         Function applied to the received seed to generate the security
         access key. When ``None`` a default inversion-based algorithm is
@@ -122,6 +125,7 @@ class UDSClient:
         is_extended_id: bool = False,
         rx_block_size: int = 0,
         rx_st_min: int = 0,
+        wft_max: int = 0,
         key_algo: "Callable[[bytes], bytes] | str | None" = None,
         source_address: "int | None" = None,
         target_address: "int | None" = None,
@@ -138,6 +142,7 @@ class UDSClient:
         self.is_extended_id = is_extended_id
         self.rx_block_size = rx_block_size
         self.rx_st_min = rx_st_min
+        self.wft_max = wft_max
         self._key_algo = _load_key_algo(key_algo)
         self.source_address = source_address
         self.target_address = target_address
@@ -226,6 +231,7 @@ class UDSClient:
             # wait for flow control
             self.logger.debug("Waiting for Flow Control frame")
             elapsed = 0.0
+            wait_count = 0
             while True:
                 remaining = fc_timeout - elapsed
                 if remaining <= 0:
@@ -256,8 +262,13 @@ class UDSClient:
                         block_size,
                         st_delay,
                     )
+                    wait_count = 0
                     break
-                self.logger.debug("Flow Control WAIT received")
+                wait_count += 1
+                self.logger.debug("Flow Control WAIT received (%d)", wait_count)
+                if wait_count > self.wft_max:
+                    self.logger.debug("Flow control WAIT limit exceeded")
+                    raise ISOTransportError("Too many Flow Control WAIT frames")
             seq = 1
             offset = first_len
             sent_in_block = 0
@@ -299,9 +310,14 @@ class UDSClient:
                                 block_size,
                                 st_delay,
                             )
+                            wait_count = 0
                             sent_in_block = 0
                             break
-                        self.logger.debug("Flow Control WAIT received")
+                        wait_count += 1
+                        self.logger.debug("Flow Control WAIT received (%d)", wait_count)
+                        if wait_count > self.wft_max:
+                            self.logger.debug("Flow control WAIT limit exceeded")
+                            raise ISOTransportError("Too many Flow Control WAIT frames")
                 chunk = payload[offset : offset + chunk_len]  # noqa: E203
                 if self.address_extension is not None:
                     cf_data = (
@@ -387,6 +403,7 @@ class UDSClient:
             "next_seq": 0,
             "bs": 0,
         }
+        wait_count = 0
         start = time.monotonic()
         while True:
             remaining = timeout - (time.monotonic() - start)
@@ -438,6 +455,13 @@ class UDSClient:
                 state["bs"] = 0
                 if self.t_data and self.t_data.som_ind:
                     self.t_data.som_ind()
+                if self._rx_fc_status == 1:
+                    wait_count += 1
+                    if wait_count > self.wft_max:
+                        self.logger.debug("Flow control WAIT limit exceeded")
+                        raise ISOTransportError("Too many Flow Control WAIT frames")
+                else:
+                    wait_count = 0
                 self._send_fc(status=self._rx_fc_status)
                 self.logger.debug("Received First Frame: total_len=%d", total_len)
                 continue
@@ -468,6 +492,13 @@ class UDSClient:
                         self.t_data.ind(payload)
                     return payload
                 if self.rx_block_size > 0 and state["bs"] >= self.rx_block_size:
+                    if self._rx_fc_status == 1:
+                        wait_count += 1
+                        if wait_count > self.wft_max:
+                            self.logger.debug("Flow control WAIT limit exceeded")
+                            raise ISOTransportError("Too many Flow Control WAIT frames")
+                    else:
+                        wait_count = 0
                     self._send_fc(status=self._rx_fc_status)
                     state["bs"] = 0
                 continue
@@ -575,9 +606,7 @@ class UDSClient:
             raise ISOTransportError("Invalid seed response")
         if rsp[0] == 0x7F:
             code = rsp[2] if len(rsp) > 2 else 0
-            raise ISOTransportError(
-                f"Security seed request denied (NRC 0x{code:02X})"
-            )
+            raise ISOTransportError(f"Security seed request denied (NRC 0x{code:02X})")
         if rsp[0] != 0x67 or rsp[1] != level * 2 - 1:
             raise ISOTransportError("Unexpected seed response")
         seed = rsp[2:]
@@ -588,9 +617,7 @@ class UDSClient:
             raise ISOTransportError("Invalid key response")
         if rsp2[0] == 0x7F:
             code = rsp2[2] if len(rsp2) > 2 else 0
-            raise ISOTransportError(
-                f"Security access denied (NRC 0x{code:02X})"
-            )
+            raise ISOTransportError(f"Security access denied (NRC 0x{code:02X})")
         if rsp2[:2] != bytes([0x67, level * 2]):
             raise ISOTransportError("Unexpected key response")
         return True

--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -307,7 +307,7 @@ def test_receive_wait_and_resume(monkeypatch):
     bus = can.interface.Bus(
         bustype="virtual", bitrate=500000, receive_own_messages=True
     )
-    client = UDSClient(bus, 0x7E0, 0x7E8)
+    client = UDSClient(bus, 0x7E0, 0x7E8, wft_max=1)
 
     ff = can.Message(
         arbitration_id=0x7E8,
@@ -347,6 +347,44 @@ def test_receive_wait_and_resume(monkeypatch):
     assert payload == bytes(range(10))
     fc_frames = [m for m in sent if (m.data[0] >> 4) == 0x3]
     assert [f.data[0] for f in fc_frames] == [0x31, 0x30]
+
+
+def test_receive_wait_overflow(monkeypatch):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    client = UDSClient(bus, 0x7E0, 0x7E8, rx_block_size=1, wft_max=1)
+
+    ff = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x10, 0x12, 0, 1, 2, 3, 4, 5]),
+        is_extended_id=False,
+    )
+    cf = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x21, 6, 7, 8, 9, 10, 11, 12]),
+        is_extended_id=False,
+    )
+
+    responses = [ff, cf]
+
+    def fake_recv(timeout):
+        if responses:
+            return responses.pop(0)
+        return None
+
+    sent: list[can.Message] = []
+
+    monkeypatch.setattr(bus, "recv", fake_recv)
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+
+    client.pause_rx()
+    with pytest.raises(ISOTransportError, match="Flow Control WAIT"):
+        client.receive(timeout=1.0)
+
+    fc_waits = [m for m in sent if (m.data[0] >> 4) == 0x3]
+    assert len(fc_waits) == 1
+    assert (fc_waits[0].data[0] & 0x0F) == 1
 
 
 def test_receive_overflow(monkeypatch):
@@ -564,7 +602,7 @@ def test_send_wait_then_cts(monkeypatch, caplog):
     )
     test_logger = logging.getLogger("uds_wait")
     test_logger.setLevel(logging.DEBUG)
-    client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger)
+    client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger, wft_max=1)
 
     sent: list[can.Message] = []
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
@@ -608,7 +646,7 @@ def test_send_wait_timeout(monkeypatch, caplog):
     )
     test_logger = logging.getLogger("uds_wait_timeout")
     test_logger.setLevel(logging.DEBUG)
-    client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger)
+    client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger, wft_max=1)
 
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
 
@@ -648,6 +686,34 @@ def test_send_wait_timeout(monkeypatch, caplog):
     assert any("No Flow Control frame received" in r.message for r in caplog.records)
 
 
+def test_send_wait_overflow(monkeypatch):
+    bus = can.interface.Bus(
+        bustype="virtual", bitrate=500000, receive_own_messages=True
+    )
+    client = UDSClient(bus, 0x7E0, 0x7E8, wft_max=1)
+
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
+
+    fc_wait = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x31, 0, 0, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+
+    calls = {"count": 0}
+
+    def fake_recv(timeout):
+        calls["count"] += 1
+        if calls["count"] <= 2:
+            return fc_wait
+        return None
+
+    monkeypatch.setattr(bus, "recv", fake_recv)
+
+    with pytest.raises(ISOTransportError, match="Flow Control WAIT"):
+        client.send(0x22, bytes(range(10)))
+
+
 def test_send_flow_control_overflow(monkeypatch, caplog):
     bus = can.interface.Bus(
         bustype="virtual", bitrate=500000, receive_own_messages=True
@@ -670,4 +736,3 @@ def test_send_flow_control_overflow(monkeypatch, caplog):
             client.send(0x22, bytes(range(10)))
 
     assert any("Flow control overflow" in r.message for r in caplog.records)
-


### PR DESCRIPTION
## Summary
- add configurable `wft_max` to `UDSClient`
- abort on excessive Flow Control WAIT frames during send and receive
- test WAIT-frame overflow scenarios for both directions

## Testing
- `pre-commit run --files src/uds.py tests/test_uds_client.py README.md`
- `pytest tests/test_uds_client.py::test_send_wait_overflow tests/test_uds_client.py::test_receive_wait_overflow -q`


------
https://chatgpt.com/codex/tasks/task_e_6899a0c18c1483249cc78366174e9475