### PR TITLE
Replace deprecated bustype usage and clean up virtual CAN buses

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -108,6 +108,23 @@ Run the monitor with the configuration:
 python -m can_monitor --interface can0 --bitrate 250000 --config uds_config.json
 ```
 
+### Testing Without Hardware
+
+The `python-can` library includes a virtual interface that simulates a CAN bus.
+This allows exercising the monitor and diagnostic tools without connecting to a
+vehicle:
+
+```python
+import can
+
+with can.interface.Bus(interface="virtual", bitrate=500000, receive_own_messages=True) as bus:
+    # interact with the bus as usual
+    ...
+```
+
+The `interface` argument supersedes the deprecated `bustype` parameter found in
+older examples.
+
 When `--print-raw` is supplied, the log records the raw CAN payload for each
 frame and, when decoding succeeds, the decoded signal dictionary.  When decoding
 fails, the log includes a message and the metrics counter `decoding_failures` is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import can
+import pytest
+
+@pytest.fixture
+def bus_factory():
+    """Create virtual CAN buses and ensure they are shut down after use."""
+    buses = []
+
+    def factory(*, bitrate=500000):
+        bus = can.interface.Bus(interface="virtual", bitrate=bitrate, receive_own_messages=True)
+        buses.append(bus)
+        return bus
+
+    yield factory
+
+    for bus in buses:
+        bus.shutdown()

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -47,12 +47,10 @@ dbc_path = os.path.join(os.path.dirname(__file__), "..", "src", "OBD.dbc")
 
 
 @pytest.mark.parametrize("bitrate", [125000, 500000])
-def test_monitor_decodes_extended_ids(bitrate, log_setup):
+def test_monitor_decodes_extended_ids(bitrate, log_setup, bus_factory):
     logger, log_file = log_setup
     db = load_dbc(dbc_path)
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=bitrate, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=bitrate)
 
     msg = can.Message(
         arbitration_id=db.messages[0].frame_id,
@@ -85,12 +83,10 @@ def test_monitor_decodes_extended_ids(bitrate, log_setup):
     assert expected in contents
 
 
-def test_monitor_without_print_raw(log_setup):
+def test_monitor_without_print_raw(log_setup, bus_factory):
     logger, log_file = log_setup
     db = load_dbc(dbc_path)
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
 
     msg = can.Message(
         arbitration_id=db.messages[0].frame_id,
@@ -121,14 +117,12 @@ def test_monitor_without_print_raw(log_setup):
     assert expected in contents
 
 
-def test_bus_off_raises_can_error(log_setup, monkeypatch):
+def test_bus_off_raises_can_error(log_setup, monkeypatch, bus_factory):
     logger, _ = log_setup
     monkeypatch.setattr(
         can.bus.BusState, "BUS_OFF", can.bus.BusState.ERROR, raising=False
     )
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
     monkeypatch.setattr(
         bus.__class__, "state", property(lambda self: can.bus.BusState.BUS_OFF)
     )
@@ -144,12 +138,10 @@ def test_bus_off_raises_can_error(log_setup, monkeypatch):
     assert get_metrics()["bus_errors"] == 1
 
 
-def test_monitor_handles_missing_dbc(log_setup):
+def test_monitor_handles_missing_dbc(log_setup, bus_factory):
     logger, log_file = log_setup
     db = None
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
     msg = can.Message(
         arbitration_id=0x18FF50E5,
         is_extended_id=True,
@@ -176,12 +168,10 @@ def test_monitor_handles_missing_dbc(log_setup):
     assert expected in contents
 
 
-def test_monitor_handles_malformed_frame(log_setup):
+def test_monitor_handles_malformed_frame(log_setup, bus_factory):
     logger, log_file = log_setup
     db = load_dbc(dbc_path)
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
     msg = can.Message(
         arbitration_id=db.messages[0].frame_id, is_extended_id=True, data=bytes([1])
     )
@@ -207,12 +197,10 @@ def test_monitor_handles_malformed_frame(log_setup):
     assert get_metrics()["decoding_failures"] == 1
 
 
-def test_monitor_continues_with_slow_transport(log_setup):
+def test_monitor_continues_with_slow_transport(log_setup, bus_factory):
     logger, _ = log_setup
     db = load_dbc(dbc_path)
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
 
     msg = can.Message(
         arbitration_id=db.messages[0].frame_id,
@@ -267,10 +255,8 @@ def test_monitor_continues_with_slow_transport(log_setup):
     assert transport.count == 2
 
 
-def test_apply_patches_sends_and_logs(caplog):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_apply_patches_sends_and_logs(caplog, bus_factory):
+    bus = bus_factory(bitrate=500000)
     patches = {
         "demo": {
             "can_id": 0x123,
@@ -297,7 +283,7 @@ def test_load_dbc_missing_file(caplog):
     assert "DBC file not found" in caplog.text
 
 
-def test_opendbc_fallback_selects_best_dbc(tmp_path):
+def test_opendbc_fallback_selects_best_dbc(tmp_path, bus_factory):
     """Ensure opendbc fallback loads the best matching DBC."""
     header = (
         'VERSION ""\n'
@@ -352,9 +338,7 @@ def test_opendbc_fallback_selects_best_dbc(tmp_path):
 
     dummy = type("Opendbc", (), {"DBC_PATH": str(tmp_path)})
 
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
     msg = can.Message(arbitration_id=0x100, is_extended_id=False, data=bytes(8))
     bus.send(msg)
 
@@ -378,11 +362,9 @@ def test_opendbc_fallback_selects_best_dbc(tmp_path):
     assert db.get_message_by_frame_id(0x100)
 
 
-def test_uds_dtc_alert(log_setup):
+def test_uds_dtc_alert(log_setup, bus_factory):
     logger, log_file = log_setup
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
 
     with open(Path(__file__).resolve().parents[1] / "uds_config.json") as f:
         uds_cfg = json.load(f)["uds"]
@@ -423,11 +405,9 @@ def test_uds_dtc_alert(log_setup):
     assert any(m.arbitration_id == 0x7E0 and m.data[0] == 0x30 for m in sent)
 
 
-def test_uds_multi_block_fc(log_setup):
+def test_uds_multi_block_fc(log_setup, bus_factory):
     logger, _ = log_setup
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
 
     with open(Path(__file__).resolve().parents[1] / "uds_config.json") as f:
         uds_cfg = json.load(f)["uds"]
@@ -474,11 +454,9 @@ def test_uds_multi_block_fc(log_setup):
     assert len(fcs) == 2
 
 
-def test_uds_fc_extended_id(log_setup):
+def test_uds_fc_extended_id(log_setup, bus_factory):
     logger, _ = log_setup
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
 
     uds_cfg = {
         "ecu_request_id": 0x18DA10F1,
@@ -524,11 +502,9 @@ def test_uds_fc_extended_id(log_setup):
     assert sent[0].data[0] == 0x30
 
 
-def test_uds_fc_address_extension(log_setup):
+def test_uds_fc_address_extension(log_setup, bus_factory):
     logger, _ = log_setup
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
 
     uds_cfg = {
         "ecu_request_id": 0x7E0,
@@ -577,11 +553,9 @@ def test_uds_fc_address_extension(log_setup):
     assert not sent[0].is_extended_id
 
 
-def test_uds_dtc_alert_extended_id(log_setup):
+def test_uds_dtc_alert_extended_id(log_setup, bus_factory):
     logger, log_file = log_setup
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
 
     with open(Path(__file__).resolve().parents[1] / "uds_config.json") as f:
         uds_cfg = json.load(f)["uds"]
@@ -631,11 +605,9 @@ def test_uds_dtc_alert_extended_id(log_setup):
     assert sent[0].arbitration_id == uds_cfg["ecu_request_id"]
 
 
-def test_uds_dtc_alert_address_extension(log_setup):
+def test_uds_dtc_alert_address_extension(log_setup, bus_factory):
     logger, log_file = log_setup
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory(bitrate=500000)
 
     with open(Path(__file__).resolve().parents[1] / "uds_config.json") as f:
         uds_cfg = json.load(f)["uds"]

--- a/tests/test_sequence_scheduler.py
+++ b/tests/test_sequence_scheduler.py
@@ -13,10 +13,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from can_monitor import _sequence_loop  # noqa: E402
 
 
-def test_sequence_interval(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_sequence_interval(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     send_times = []
     monkeypatch.setattr(
         bus, "send", lambda msg, timeout=None: send_times.append(time.monotonic())
@@ -37,10 +35,8 @@ def test_sequence_interval(monkeypatch):
         assert pytest.approx(iv, rel=0.2) == 0.02
 
 
-def test_sequence_multiframe(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_sequence_multiframe(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     sent = []
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
     ff = can.Message(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -65,7 +65,7 @@ def _run_server(server: HTTPServer) -> None:
 
 
 @pytest.mark.parametrize("fmt", ["json", "csv"])
-def test_http_transport_formats(fmt, log_setup):
+def test_http_transport_formats(fmt, log_setup, bus_factory):
     logger, _ = log_setup
     db = load_dbc(dbc_path)
 
@@ -79,9 +79,7 @@ def test_http_transport_formats(fmt, log_setup):
     headers = {"Content-Type": "application/json" if fmt == "json" else "text/csv"}
     transport = HTTPTransport(url, headers=headers, retries=1, delay=0)
 
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory()
     msg = can.Message(
         arbitration_id=db.messages[0].frame_id,
         is_extended_id=True,
@@ -122,7 +120,7 @@ def test_http_transport_formats(fmt, log_setup):
         assert payload.strip() == expected
 
 
-def test_http_transport_retry(log_setup):
+def test_http_transport_retry(log_setup, bus_factory):
     logger, _ = log_setup
     db = load_dbc(dbc_path)
 
@@ -137,9 +135,7 @@ def test_http_transport_retry(log_setup):
         url, headers={"Content-Type": "application/json"}, retries=2, delay=0
     )
 
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+    bus = bus_factory()
     msg = can.Message(
         arbitration_id=db.messages[0].frame_id,
         is_extended_id=True,

--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -14,10 +14,8 @@ from uds import UDSClient, ISOTransportError  # noqa: E402
 from isotp_primitives import TDataPrimitive  # noqa: E402
 
 
-def test_send_segments_respects_flow_control(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_send_segments_respects_flow_control(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8, key_algo="uds:default_key_algo")
 
     sent = []
@@ -53,10 +51,8 @@ def test_send_segments_respects_flow_control(monkeypatch):
     assert sleeps and pytest.approx(sleeps[0], rel=0.1) == 0.001
 
 
-def test_send_cumulative_fc_timeout(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_send_cumulative_fc_timeout(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
 
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
@@ -93,10 +89,8 @@ def test_send_cumulative_fc_timeout(monkeypatch):
         client.send(0x22, data, timeout=1.0)
 
 
-def test_send_rejects_overly_large_payload(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_send_rejects_overly_large_payload(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
 
     sent = []
@@ -108,10 +102,8 @@ def test_send_rejects_overly_large_payload(monkeypatch):
     assert not sent
 
 
-def test_request_handles_response_pending(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_request_handles_response_pending(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
 
@@ -136,10 +128,8 @@ def test_request_handles_response_pending(monkeypatch):
     assert payload[:2] == bytes([0x50, 0x03])
 
 
-def test_session_and_security(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_session_and_security(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
 
     sent: list[can.Message] = []
@@ -178,10 +168,8 @@ def test_session_and_security(monkeypatch):
     assert sent[2].data[:5] == bytes([0x04, 0x27, 0x02, 0x55, 0x44])
 
 
-def test_security_access_invalid_key(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_security_access_invalid_key(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
 
@@ -202,10 +190,8 @@ def test_security_access_invalid_key(monkeypatch):
         client.security_access(1, b"\x00\x00")
 
 
-def test_security_access_negative_response(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_security_access_negative_response(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
 
@@ -220,10 +206,8 @@ def test_security_access_negative_response(monkeypatch):
         client.security_access(1, b"\x00\x00")
 
 
-def test_extended_addressing(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_extended_addressing(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8, address_extension=0x99)
 
     sent: list[can.Message] = []
@@ -243,10 +227,8 @@ def test_extended_addressing(monkeypatch):
     assert payload == bytes([0x50, 0x03])
 
 
-def test_normal_fixed_addressing(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_normal_fixed_addressing(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0, 0, source_address=0xF1, target_address=0x10)
 
     sent: list[can.Message] = []
@@ -267,10 +249,8 @@ def test_normal_fixed_addressing(monkeypatch):
     assert payload[:2] == bytes([0x7F, 0x31])
 
 
-def test_tdata_primitives(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_tdata_primitives(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     calls = []
     t_data = TDataPrimitive(
         req=lambda s, d: calls.append(("req", s, d)),
@@ -306,10 +286,8 @@ def test_tdata_primitives(monkeypatch):
     ]
 
 
-def test_receive_sequence_number_mismatch(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_receive_sequence_number_mismatch(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
 
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
@@ -331,10 +309,8 @@ def test_receive_sequence_number_mismatch(monkeypatch):
         client.receive()
 
 
-def test_receive_wait_and_resume(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_receive_wait_and_resume(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8, wft_max=1)
 
     ff = can.Message(
@@ -377,10 +353,8 @@ def test_receive_wait_and_resume(monkeypatch):
     assert [f.data[0] for f in fc_frames] == [0x31, 0x30]
 
 
-def test_receive_wait_overflow(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_receive_wait_overflow(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8, rx_block_size=1, wft_max=1)
 
     ff = can.Message(
@@ -415,10 +389,8 @@ def test_receive_wait_overflow(monkeypatch):
     assert (fc_waits[0].data[0] & 0x0F) == 1
 
 
-def test_receive_overflow(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_receive_overflow(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8, max_rx_size=4)
 
     ff = can.Message(
@@ -438,10 +410,8 @@ def test_receive_overflow(monkeypatch):
     assert fc_frames and fc_frames[0].data[0] == 0x32
 
 
-def test_receive_reset_warns_and_calls_hook(monkeypatch, caplog):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_receive_reset_warns_and_calls_hook(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
     hooks: list[str] = []
     client = UDSClient(bus, 0x7E0, 0x7E8, on_reset=lambda: hooks.append("reset"))
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
@@ -469,10 +439,8 @@ def test_receive_reset_warns_and_calls_hook(monkeypatch, caplog):
     assert any("unexpected start-of-frame" in r.message for r in caplog.records)
 
 
-def test_receive_reset_raises_with_error_on_reset(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_receive_reset_raises_with_error_on_reset(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     hooks: list[str] = []
     client = UDSClient(
         bus,
@@ -504,10 +472,8 @@ def test_receive_reset_raises_with_error_on_reset(monkeypatch):
     assert hooks == ["reset"]
 
 
-def test_request_tuple_timeouts(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_request_tuple_timeouts(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
 
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
@@ -548,10 +514,8 @@ def test_request_tuple_timeouts(monkeypatch):
         client.request(0x22, b"\x01", timeout=(1.0, 0.1))
 
 
-def test_logging_debug(monkeypatch, caplog):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_logging_debug(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
     test_logger = logging.getLogger("uds_test")
     test_logger.setLevel(logging.DEBUG)
     client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger)
@@ -572,10 +536,8 @@ def test_logging_debug(monkeypatch, caplog):
     assert any("Received Single Frame" in r.message for r in caplog.records)
 
 
-def test_request_thread_locking(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_request_thread_locking(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
 
     resp = can.Message(
@@ -624,10 +586,8 @@ def test_request_thread_locking(monkeypatch):
     t.join()
 
 
-def test_send_wait_then_cts(monkeypatch, caplog):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_send_wait_then_cts(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
     test_logger = logging.getLogger("uds_wait")
     test_logger.setLevel(logging.DEBUG)
     client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger, wft_max=1)
@@ -668,10 +628,8 @@ def test_send_wait_then_cts(monkeypatch, caplog):
     assert any("Flow Control WAIT received" in r.message for r in caplog.records)
 
 
-def test_send_wait_timeout(monkeypatch, caplog):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_send_wait_timeout(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
     test_logger = logging.getLogger("uds_wait_timeout")
     test_logger.setLevel(logging.DEBUG)
     client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger, wft_max=1)
@@ -714,10 +672,8 @@ def test_send_wait_timeout(monkeypatch, caplog):
     assert any("No Flow Control frame received" in r.message for r in caplog.records)
 
 
-def test_send_wait_overflow(monkeypatch):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_send_wait_overflow(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8, wft_max=1)
 
     monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
@@ -742,10 +698,8 @@ def test_send_wait_overflow(monkeypatch):
         client.send(0x22, bytes(range(10)))
 
 
-def test_send_flow_control_overflow(monkeypatch, caplog):
-    bus = can.interface.Bus(
-        bustype="virtual", bitrate=500000, receive_own_messages=True
-    )
+def test_send_flow_control_overflow(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
     test_logger = logging.getLogger("uds_overflow")
     test_logger.setLevel(logging.DEBUG)
     client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger)


### PR DESCRIPTION
## Summary
- replace deprecated `bustype` argument with `interface`
- ensure virtual CAN buses are properly shut down using a shared fixture
- document how to use python-can's virtual interface for hardware-free testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899a7b002088324932aac56061a5be8