### PR TITLE
Add flag to suppress OBD logs

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -80,6 +80,7 @@ Additional options:
 - `--log-level DEBUG` – increase verbosity.
 - `--listen-only` – avoid transmitting frames.
 - `--print-raw` – include raw CAN payloads in the log.
+- `--uds-only` – suppress normal CAN frame logs and print only UDS output.
 
 - `--config settings.json` – load options from a JSON file (`log_level`, startup
   sequence, etc.).

--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -376,6 +376,7 @@ def monitor(
     serializer: Optional[str] = None,
     transport: Optional[Transport] = None,
     print_raw: bool = False,
+    uds_only: bool = False,
     fallback_dbs: Optional[list[Database]] = None,
     uds_config: Optional[dict[str, Any]] = None,
     sequence: Optional[list[dict[str, Any]]] = None,
@@ -460,20 +461,22 @@ def monitor(
                     )
                 except KeyError:
                     record_decoding_failure()
-                    if msg.arbitration_id not in missing_ids:
-                        missing_ids.add(msg.arbitration_id)
-                        logger.info(
-                            "No DBC entry for id=0x%s", fmt % msg.arbitration_id
-                        )
-                    else:
-                        logger.debug(
-                            "No DBC entry for id=0x%s", fmt % msg.arbitration_id
-                        )
+                    if not uds_only:
+                        if msg.arbitration_id not in missing_ids:
+                            missing_ids.add(msg.arbitration_id)
+                            logger.info(
+                                "No DBC entry for id=0x%s", fmt % msg.arbitration_id
+                            )
+                        else:
+                            logger.debug(
+                                "No DBC entry for id=0x%s", fmt % msg.arbitration_id
+                            )
                 except Exception as exc:
                     record_decoding_failure()
-                    logger.warning(
-                        "Decoding error for id=0x%s: %s", fmt % msg.arbitration_id, exc
-                    )
+                    if not uds_only:
+                        logger.warning(
+                            "Decoding error for id=0x%s: %s", fmt % msg.arbitration_id, exc
+                        )
             elif fallback_dbs:
                 for candb in fallback_dbs:
                     try:
@@ -485,30 +488,33 @@ def monitor(
                         continue
                     except Exception as exc:
                         record_decoding_failure()
-                        logger.warning(
-                            "Decoding error for id=0x%s: %s",
-                            fmt % msg.arbitration_id,
-                            exc,
-                        )
+                        if not uds_only:
+                            logger.warning(
+                                "Decoding error for id=0x%s: %s",
+                                fmt % msg.arbitration_id,
+                                exc,
+                            )
                 if decoded is None:
                     record_decoding_failure()
-                    if msg.arbitration_id not in missing_ids:
-                        missing_ids.add(msg.arbitration_id)
-                        logger.info(
-                            "No DBC entry for id=0x%s", fmt % msg.arbitration_id
-                        )
-                    else:
-                        logger.debug(
-                            "No DBC entry for id=0x%s", fmt % msg.arbitration_id
-                        )
+                    if not uds_only:
+                        if msg.arbitration_id not in missing_ids:
+                            missing_ids.add(msg.arbitration_id)
+                            logger.info(
+                                "No DBC entry for id=0x%s", fmt % msg.arbitration_id
+                            )
+                        else:
+                            logger.debug(
+                                "No DBC entry for id=0x%s", fmt % msg.arbitration_id
+                            )
 
-            if print_raw:
-                line = f"id=0x{fmt % msg.arbitration_id} raw={raw}"
-                if decoded is not None:
-                    line += f" decoded={decoded}"
-                logger.info(line)
-            elif decoded is not None:
-                logger.info("id=0x%s decoded=%s", fmt % msg.arbitration_id, decoded)
+            if not uds_only:
+                if print_raw:
+                    line = f"id=0x{fmt % msg.arbitration_id} raw={raw}"
+                    if decoded is not None:
+                        line += f" decoded={decoded}"
+                    logger.info(line)
+                elif decoded is not None:
+                    logger.info("id=0x%s decoded=%s", fmt % msg.arbitration_id, decoded)
 
             if send_queue is not None:
                 payload = serialize_frame(
@@ -554,6 +560,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--print-raw",
         action="store_true",
         help="Print raw CAN frames alongside decoded data",
+    )
+    parser.add_argument(
+        "--uds-only",
+        action="store_true",
+        help="Suppress normal CAN logs and show only UDS-related output",
     )
     parser.add_argument("--config", help="Path to JSON configuration file")
     parser.add_argument("--log-level", help="Logging level (e.g. INFO, DEBUG)")
@@ -665,6 +676,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                     db,
                     logger,
                     print_raw=args.print_raw,
+                    uds_only=args.uds_only,
                     fallback_dbs=fallback_dbs,
                     uds_config=uds_cfg,
                     sequence=sequence_cfg,

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -655,3 +655,47 @@ def test_uds_dtc_alert_address_extension(log_setup, bus_factory):
     assert sent and sent[0].data[0] == 0x99
     assert not sent[0].is_extended_id
 
+
+def test_uds_only_suppresses_obd_logs(log_setup, bus_factory):
+    logger, log_file = log_setup
+    bus = bus_factory(bitrate=500000)
+    uds_cfg = {"ecu_request_id": 0x7E0, "ecu_response_id": 0x7E8}
+
+    uds_msg = can.Message(
+        arbitration_id=uds_cfg["ecu_response_id"],
+        is_extended_id=False,
+        data=bytes([0x03, 0x7F, 0x10, 0x11, 0, 0, 0, 0]),
+    )
+    normal_msg = can.Message(
+        arbitration_id=0x123,
+        is_extended_id=False,
+        data=bytes([1, 2, 3, 4, 5, 6, 7, 8]),
+    )
+    bus.send(uds_msg)
+    bus.send(normal_msg)
+
+    orig_recv = bus.recv
+    calls = 0
+
+    def fake_recv(timeout=1.0):
+        nonlocal calls
+        if calls < 2:
+            calls += 1
+            return orig_recv(timeout)
+        raise can.CanError("stop")
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv):
+            monitor(
+                bus,
+                None,
+                logger,
+                print_raw=True,
+                uds_config=uds_cfg,
+                uds_only=True,
+            )
+
+    contents = log_file.read_text()
+    assert "UDS Negative Response" in contents
+    assert f"id=0x{normal_msg.arbitration_id:03X}" not in contents
+


### PR DESCRIPTION
## Summary
- add `--uds-only` flag to can_monitor to suppress normal CAN logs while still showing UDS messages
- document new flag in getting started guide
- test that `uds_only` mode omits OBD frame logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899af9d4a3483248a7f19a88d64785a