### PR TITLE
Add flag to log only UDS operations

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -80,6 +80,7 @@ Additional options:
 - `--log-level DEBUG` – increase verbosity.
 - `--listen-only` – avoid transmitting frames.
 - `--print-raw` – include raw CAN payloads in the log.
+- `--uds-only` – suppress normal CAN frame logs and show only UDS activity.
 
 - `--config settings.json` – load options from a JSON file (`log_level`, startup
   sequence, etc.).

--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -380,6 +380,7 @@ def monitor(
     uds_config: Optional[dict[str, Any]] = None,
     sequence: Optional[list[dict[str, Any]]] = None,
     interval_ms: int = 500,
+    log_obd: bool = True,
 ) -> None:
     send_queue: queue.Queue[str] | None = None
     if serializer and transport:
@@ -460,20 +461,24 @@ def monitor(
                     )
                 except KeyError:
                     record_decoding_failure()
-                    if msg.arbitration_id not in missing_ids:
-                        missing_ids.add(msg.arbitration_id)
-                        logger.info(
-                            "No DBC entry for id=0x%s", fmt % msg.arbitration_id
-                        )
-                    else:
-                        logger.debug(
-                            "No DBC entry for id=0x%s", fmt % msg.arbitration_id
-                        )
+                    if log_obd:
+                        if msg.arbitration_id not in missing_ids:
+                            missing_ids.add(msg.arbitration_id)
+                            logger.info(
+                                "No DBC entry for id=0x%s", fmt % msg.arbitration_id
+                            )
+                        else:
+                            logger.debug(
+                                "No DBC entry for id=0x%s", fmt % msg.arbitration_id
+                            )
                 except Exception as exc:
                     record_decoding_failure()
-                    logger.warning(
-                        "Decoding error for id=0x%s: %s", fmt % msg.arbitration_id, exc
-                    )
+                    if log_obd:
+                        logger.warning(
+                            "Decoding error for id=0x%s: %s",
+                            fmt % msg.arbitration_id,
+                            exc,
+                        )
             elif fallback_dbs:
                 for candb in fallback_dbs:
                     try:
@@ -485,30 +490,33 @@ def monitor(
                         continue
                     except Exception as exc:
                         record_decoding_failure()
-                        logger.warning(
-                            "Decoding error for id=0x%s: %s",
-                            fmt % msg.arbitration_id,
-                            exc,
-                        )
+                        if log_obd:
+                            logger.warning(
+                                "Decoding error for id=0x%s: %s",
+                                fmt % msg.arbitration_id,
+                                exc,
+                            )
                 if decoded is None:
                     record_decoding_failure()
-                    if msg.arbitration_id not in missing_ids:
-                        missing_ids.add(msg.arbitration_id)
-                        logger.info(
-                            "No DBC entry for id=0x%s", fmt % msg.arbitration_id
-                        )
-                    else:
-                        logger.debug(
-                            "No DBC entry for id=0x%s", fmt % msg.arbitration_id
-                        )
+                    if log_obd:
+                        if msg.arbitration_id not in missing_ids:
+                            missing_ids.add(msg.arbitration_id)
+                            logger.info(
+                                "No DBC entry for id=0x%s", fmt % msg.arbitration_id
+                            )
+                        else:
+                            logger.debug(
+                                "No DBC entry for id=0x%s", fmt % msg.arbitration_id
+                            )
 
-            if print_raw:
-                line = f"id=0x{fmt % msg.arbitration_id} raw={raw}"
-                if decoded is not None:
-                    line += f" decoded={decoded}"
-                logger.info(line)
-            elif decoded is not None:
-                logger.info("id=0x%s decoded=%s", fmt % msg.arbitration_id, decoded)
+            if log_obd:
+                if print_raw:
+                    line = f"id=0x{fmt % msg.arbitration_id} raw={raw}"
+                    if decoded is not None:
+                        line += f" decoded={decoded}"
+                    logger.info(line)
+                elif decoded is not None:
+                    logger.info("id=0x%s decoded=%s", fmt % msg.arbitration_id, decoded)
 
             if send_queue is not None:
                 payload = serialize_frame(
@@ -554,6 +562,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--print-raw",
         action="store_true",
         help="Print raw CAN frames alongside decoded data",
+    )
+    parser.add_argument(
+        "--uds-only",
+        action="store_true",
+        help="Only log UDS operations, suppress normal CAN frame logs",
     )
     parser.add_argument("--config", help="Path to JSON configuration file")
     parser.add_argument("--log-level", help="Logging level (e.g. INFO, DEBUG)")
@@ -669,6 +682,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                     uds_config=uds_cfg,
                     sequence=sequence_cfg,
                     interval_ms=interval_ms,
+                    log_obd=not args.uds_only,
                 )
                 delay = 1.0
         except can.CanError as exc:

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -197,6 +197,45 @@ def test_monitor_handles_malformed_frame(log_setup, bus_factory):
     assert get_metrics()["decoding_failures"] == 1
 
 
+def test_monitor_uds_only_logs_uds_frames(log_setup, bus_factory):
+    logger, log_file = log_setup
+    db = load_dbc(dbc_path)
+    bus = bus_factory(bitrate=500000)
+
+    normal = can.Message(
+        arbitration_id=db.messages[0].frame_id,
+        is_extended_id=True,
+        data=bytes([10, 20, 0, 0, 0, 0, 0, 0]),
+    )
+    bus.send(normal)
+
+    uds_cfg = {"ecu_request_id": 0x7E0, "ecu_response_id": 0x7E8}
+    uds_msg = can.Message(
+        arbitration_id=uds_cfg["ecu_response_id"],
+        data=bytes([0x03, 0x7F, 0x10, 0x11, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    bus.send(uds_msg)
+
+    orig_recv = bus.recv
+    calls = 0
+
+    def fake_recv(timeout=1.0):
+        nonlocal calls
+        if calls < 2:
+            calls += 1
+            return orig_recv(timeout)
+        raise can.CanError("stop")
+
+    with pytest.raises(can.CanError):
+        with patch.object(bus, "recv", side_effect=fake_recv):
+            monitor(bus, db, logger, uds_config=uds_cfg, log_obd=False)
+
+    contents = log_file.read_text()
+    assert "UDS Negative Response" in contents
+    assert "decoded=" not in contents
+
+
 def test_monitor_continues_with_slow_transport(log_setup, bus_factory):
     logger, _ = log_setup
     db = load_dbc(dbc_path)
@@ -419,7 +458,9 @@ def test_uds_multi_block_fc(log_setup, bus_factory):
     length = len(payload)
     ff = can.Message(
         arbitration_id=0x7E8,
-        data=bytes([0x10 | ((length >> 8) & 0x0F), length & 0xFF]) + payload[:6] + bytes(8 - 2 - 6),
+        data=bytes([0x10 | ((length >> 8) & 0x0F), length & 0xFF])
+        + payload[:6]
+        + bytes(8 - 2 - 6),
         is_extended_id=False,
     )
     cf1 = can.Message(
@@ -524,9 +565,7 @@ def test_uds_fc_address_extension(log_setup, bus_factory):
     )
     cf = can.Message(
         arbitration_id=uds_cfg["ecu_response_id"],
-        data=bytes([0x99, 0x21])
-        + payload[5:11]
-        + bytes(6 - len(payload[5:11])),
+        data=bytes([0x99, 0x21]) + payload[5:11] + bytes(6 - len(payload[5:11])),
         is_extended_id=False,
     )
     frames = [ff, cf]
@@ -654,4 +693,3 @@ def test_uds_dtc_alert_address_extension(log_setup, bus_factory):
     assert "DTC P20F9" in contents
     assert sent and sent[0].data[0] == 0x99
     assert not sent[0].is_extended_id
-


### PR DESCRIPTION
## Summary
- add `--uds-only` flag to suppress normal CAN frame logs
- document UDS-only option and add regression test

## Testing
- `pre-commit run --files src/can_monitor.py tests/test_can_monitor.py docs/GETTING_STARTED.md`

------
https://chatgpt.com/codex/tasks/task_e_6899af9d4a3483248a7f19a88d64785a