### PR TITLE
Fix DTC parsing for reportDTCByStatusMask

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -193,12 +193,12 @@ def _process_uds_payload(
     if len(payload) < 3:
         return
     if payload[0] == 0x59 and payload[1] == 0x02:
-        dtc_count = payload[2]
+        # Response to reportDTCByStatusMask. Byte 2 is the status
+        # availability mask, followed by repeated <DTC+status> records.
         entries = payload[3:]
+        dtc_count = len(entries) // 4
         for i in range(dtc_count):
             start = i * 4
-            if start + 4 > len(entries):
-                break
             code = _convert_to_pcode(entries[start : start + 3])  # noqa: E203
             info = uds_config.get("dtcs", {}).get(code)
             if info:

--- a/tests/test_dtc_parsing.py
+++ b/tests/test_dtc_parsing.py
@@ -1,0 +1,22 @@
+import logging
+
+from can_monitor import _process_uds_payload
+
+
+def test_process_uds_payload_parses_dtc(caplog):
+    payload = bytes.fromhex("59 02 FF 05 8D 00 10")
+    state = {}
+    uds_config = {
+        "dtcs": {
+            "P058D": {
+                "description": "Dual Aux communication failure",
+                "severity": "MAJOR",
+                "alert": False,
+                "component": "AUX",
+            }
+        }
+    }
+    logger = logging.getLogger("test")
+    with caplog.at_level(logging.INFO):
+        _process_uds_payload(payload, state, uds_config, logger)
+    assert "DTC P058D" in caplog.text


### PR DESCRIPTION
## Summary
- parse reportDTCByStatusMask responses using status mask instead of count
- add regression test for DTC parsing

## Testing
- `pre-commit run --files src/can_monitor.py tests/test_dtc_parsing.py`

------
https://chatgpt.com/codex/tasks/task_e_6899d0b4e744832495672bb012b06285