### PR TITLE
Enforce privilege checks for CAN setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ The utilities and tests rely on a few Python packages:
 
 Install them with `pip install -r requirements.txt`.
 
+## Privilege Requirements
+
+Configuring a SocketCAN interface requires root privileges or the
+`CAP_NET_ADMIN` capability. To grant the capability to the Python
+interpreter without running as root:
+
+```bash
+sudo setcap cap_net_admin+ep $(readlink -f $(which python3))
+```
+
 If the bundled `OBD.dbc` cannot be loaded, the CAN monitor will
 automatically fall back to the community DBC files provided by
 [`opendbc`](https://github.com/commaai/opendbc).

--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -2,9 +2,10 @@
 """CAN bus monitor for SocketCAN interfaces.
 
 This module sets up a SocketCAN interface, loads a DBC file, and
-continuously logs raw and decoded CAN messages.  It includes support
-for listen-only mode on modern python-can versions and tolerates removal
-of the BUS_OFF enum, preventing controller lockouts.
+continuously logs raw and decoded CAN messages.  Configuring the
+interface requires root privileges or the ``CAP_NET_ADMIN`` capability.
+It includes support for listen-only mode on modern python-can versions
+and tolerates removal of the BUS_OFF enum, preventing controller lockouts.
 """
 
 from __future__ import annotations

--- a/src/canbus/__init__.py
+++ b/src/canbus/__init__.py
@@ -1,4 +1,9 @@
-"""Utilities for CAN bus management."""
+"""Utilities for CAN bus management.
+
+Configuring interfaces requires either root privileges or the
+``CAP_NET_ADMIN`` capability.  Grant the capability with ``setcap
+cap_net_admin+ep`` on the Python interpreter to avoid running as root.
+"""
 
 from .setup import setup_interface, SystemCommands, MockCommands
 

--- a/src/canbus/setup.py
+++ b/src/canbus/setup.py
@@ -1,15 +1,31 @@
 """CAN bus setup utilities.
 
 This module centralizes system-level commands required to configure a
-SocketCAN interface.  A pluggable command interface allows the commands to
-be mocked during unit tests or replaced for alternative hardware variants.
+SocketCAN interface.  Configuring interfaces requires either root privileges
+or the ``CAP_NET_ADMIN`` capability; the latter can be granted with
+``setcap cap_net_admin+ep`` on the Python interpreter.  A pluggable command
+interface allows the commands to be mocked during unit tests or replaced for
+alternative hardware variants.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from typing import Protocol, Sequence
+
+
+def _has_cap_net_admin() -> bool:
+    try:
+        with open("/proc/self/status") as status:
+            for line in status:
+                if line.startswith("CapEff:"):
+                    value = int(line.split()[1], 16)
+                    return bool(value & (1 << 12))  # CAP_NET_ADMIN
+    except OSError:
+        pass
+    return False
 
 
 class CommandRunner(Protocol):
@@ -18,7 +34,7 @@ class CommandRunner(Protocol):
     def modprobe(self, module: str) -> int:
         """Load a kernel module."""
 
-    def ip(self, args: Sequence[str]) -> int:
+    def ip(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         """Run an ``ip`` command with the given arguments."""
 
 
@@ -33,8 +49,10 @@ class SystemCommands:
     def modprobe(self, module: str) -> int:
         return subprocess.run(["modprobe", module], check=False).returncode
 
-    def ip(self, args: Sequence[str]) -> int:
-        return subprocess.run(["ip", *args], check=False).returncode
+    def ip(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["ip", *args], check=False, capture_output=True, text=True
+        )
 
 
 class MockCommands:
@@ -42,21 +60,26 @@ class MockCommands:
 
     This implementation is useful in unit tests where side effects are
     undesirable.  For readability, each command is stored as the string
-    that would be executed on the command line.
+    that would be executed on the command line.  ``ip`` results may be
+    pre-populated via :attr:`ip_results` to simulate failures.
     """
 
     def __init__(self) -> None:
         self.commands: list[str] = []
+        self.ip_results: list[tuple[int, str]] = []
 
     def modprobe(self, module: str) -> int:  # pragma: no cover - simple
         cmd = f"modprobe {module}"
         self.commands.append(cmd)
         return 0
 
-    def ip(self, args: Sequence[str]) -> int:  # pragma: no cover - simple
+    def ip(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         cmd = "ip " + " ".join(args)
         self.commands.append(cmd)
-        return 0
+        rc, err = (0, "")
+        if self.ip_results:
+            rc, err = self.ip_results.pop(0)
+        return subprocess.CompletedProcess(["ip", *args], rc, "", err)
 
 
 def setup_interface(
@@ -67,6 +90,9 @@ def setup_interface(
     commands: CommandRunner | None = None,
 ) -> None:
     """Configure a SocketCAN interface.
+
+    Requires either root privileges or the ``CAP_NET_ADMIN`` capability to
+    execute the underlying ``ip`` commands.
 
     Parameters
     ----------
@@ -82,12 +108,32 @@ def setup_interface(
 
     cmd = commands or SystemCommands()
 
+    if os.geteuid() != 0 and not _has_cap_net_admin():
+        msg = "Configuring CAN interfaces requires root or CAP_NET_ADMIN capability"
+        logging.critical(msg)
+        raise RuntimeError(msg)
+
     if cmd.modprobe("can") != 0:
         logging.warning("Failed to load 'can' kernel module")
     if cmd.modprobe("can_raw") != 0:
         logging.warning("Failed to load 'can_raw' kernel module")
-    if cmd.ip(["link", "set", interface, "down"]) != 0:
-        logging.warning("Failed to bring down %s", interface)
+
+    def run_ip(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        result = cmd.ip(args)
+        if result.returncode != 0:
+            err = result.stderr.strip()
+            if "Operation not permitted" in err:
+                raise RuntimeError(f"Permission denied running 'ip {' '.join(args)}'")
+            if "Invalid argument" in err:
+                raise ValueError(
+                    "Invalid argument running 'ip {}' – unsupported bitrate".format(
+                        " ".join(args)
+                    )
+                )
+            logging.warning("ip %s failed: %s", " ".join(args), err)
+        return result
+
+    run_ip(["link", "set", interface, "down"])
 
     up_args = [
         "link",
@@ -99,22 +145,17 @@ def setup_interface(
         "bitrate",
         str(bitrate),
     ]
-    if cmd.ip(up_args) != 0:
-        logging.warning("Failed to configure %s", interface)
+    run_ip(up_args)
 
     if listen_only:
-        if (
-            cmd.ip(
-                [
-                    "link",
-                    "set",
-                    interface,
-                    "type",
-                    "can",
-                    "listen-only",
-                    "on",
-                ]
-            )
-            != 0
-        ):
-            logging.warning("Failed to enable listen-only mode on %s", interface)
+        run_ip(
+            [
+                "link",
+                "set",
+                interface,
+                "type",
+                "can",
+                "listen-only",
+                "on",
+            ]
+        )

--- a/tests/test_canbus_setup.py
+++ b/tests/test_canbus_setup.py
@@ -1,12 +1,17 @@
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from canbus.setup import MockCommands, setup_interface  # noqa: E402
 
 
-def test_setup_interface_builds_commands():
+def test_setup_interface_builds_commands(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr("canbus.setup._has_cap_net_admin", lambda: True)
     mock = MockCommands()
     setup_interface("can0", 250000, True, commands=mock)
     assert mock.commands == [
@@ -16,3 +21,33 @@ def test_setup_interface_builds_commands():
         "ip link set can0 up type can bitrate 250000",
         "ip link set can0 type can listen-only on",
     ]
+
+
+def test_setup_interface_requires_privileges(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.setattr("canbus.setup._has_cap_net_admin", lambda: False)
+    mock = MockCommands()
+    with pytest.raises(RuntimeError, match="CAP_NET_ADMIN"):
+        setup_interface("can0", 250000, commands=mock)
+    assert mock.commands == []
+
+
+def test_setup_interface_ip_permission_error(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr("canbus.setup._has_cap_net_admin", lambda: True)
+    mock = MockCommands()
+    mock.ip_results = [(1, "RTNETLINK answers: Operation not permitted")]
+    with pytest.raises(RuntimeError, match="Permission denied"):
+        setup_interface("can0", 250000, commands=mock)
+
+
+def test_setup_interface_invalid_bitrate(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr("canbus.setup._has_cap_net_admin", lambda: True)
+    mock = MockCommands()
+    mock.ip_results = [
+        (0, ""),
+        (2, "RTNETLINK answers: Invalid argument"),
+    ]
+    with pytest.raises(ValueError, match="unsupported bitrate"):
+        setup_interface("can0", 12345, commands=mock)


### PR DESCRIPTION
## Summary
- require root or CAP_NET_ADMIN when configuring CAN interfaces
- surface permission and bitrate errors from ip command failures
- document privilege requirements and add unit tests for failure scenarios

## Testing
- `pre-commit run --files src/canbus/setup.py src/canbus/__init__.py src/can_monitor.py README.md tests/test_canbus_setup.py`
- `pytest tests/test_canbus_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_689a21701ffc8324853ac5600bdb734c