### PR TITLE
Add CAN interface restart failure counter

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -606,14 +606,39 @@ def main(argv: Optional[list[str]] = None) -> int:
     else:
         logger.info("DBC loaded with %d messages", len(db.messages))
 
-    # bring up the CAN interface
-    setup_interface(args.interface, args.bitrate, args.listen_only)
+    max_failures = 3
+    failure_count = 0
+
+    def setup_with_counter() -> bool:
+        nonlocal failure_count
+        try:
+            setup_interface(args.interface, args.bitrate, args.listen_only)
+        except Exception as exc:  # pragma: no cover - log and count
+            failure_count += 1
+            logger.error("Failed to set up CAN interface: %s", exc)
+            return False
+        else:
+            if failure_count > 0:
+                logger.info("CAN interface reset and up")
+            failure_count = 0
+            return True
+
+    delay = 1.0
+    while not setup_with_counter():
+        if failure_count >= max_failures:
+            logger.fatal(
+                "Exceeded maximum consecutive CAN errors (%d); exiting", max_failures
+            )
+            return 1
+        time.sleep(delay)
+        delay = min(delay * 2, 30.0)
+        record_restart()
+    delay = 1.0
 
     if can is None:
         logger.error("python-can is required but not installed")
         return 1
 
-    delay = 1.0
     while True:
         try:
             with can.interface.Bus(
@@ -689,20 +714,52 @@ def main(argv: Optional[list[str]] = None) -> int:
         except can.CanError as exc:
             record_bus_error()
             logger.error("CAN error: %s. Restarting interface...", exc)
+            failure_count += 1
+            if failure_count >= max_failures:
+                logger.fatal(
+                    "Exceeded maximum consecutive CAN errors (%d); exiting",
+                    max_failures,
+                )
+                return 1
             time.sleep(delay)
             delay = min(delay * 2, 30.0)
             record_restart()
-            setup_interface(args.interface, args.bitrate, args.listen_only)
+            while not setup_with_counter():
+                if failure_count >= max_failures:
+                    logger.fatal(
+                        "Exceeded maximum consecutive CAN errors (%d); exiting",
+                        max_failures,
+                    )
+                    return 1
+                time.sleep(delay)
+                delay = min(delay * 2, 30.0)
+                record_restart()
         except KeyboardInterrupt:
             logger.info("Interrupted by user")
             break
         except Exception as exc:
             record_bus_error()
             logger.exception("Unexpected error: %s", exc)
+            failure_count += 1
+            if failure_count >= max_failures:
+                logger.fatal(
+                    "Exceeded maximum consecutive CAN errors (%d); exiting",
+                    max_failures,
+                )
+                return 1
             time.sleep(delay)
             delay = min(delay * 2, 30.0)
             record_restart()
-            setup_interface(args.interface, args.bitrate, args.listen_only)
+            while not setup_with_counter():
+                if failure_count >= max_failures:
+                    logger.fatal(
+                        "Exceeded maximum consecutive CAN errors (%d); exiting",
+                        max_failures,
+                    )
+                    return 1
+                time.sleep(delay)
+                delay = min(delay * 2, 30.0)
+                record_restart()
 
     return 0
 

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -14,7 +14,13 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from can_monitor import load_dbc, load_opendbc_dbs, monitor, apply_patches  # noqa: E402
+from can_monitor import (
+    load_dbc,
+    load_opendbc_dbs,
+    monitor,
+    apply_patches,
+    main,
+)  # noqa: E402
 from metrics import get_metrics, reset_metrics  # noqa: E402
 
 if not hasattr(can.bus.BusState, "BUS_OFF"):
@@ -693,3 +699,28 @@ def test_uds_dtc_alert_address_extension(log_setup, bus_factory):
     assert "DTC P20F9" in contents
     assert sent and sent[0].data[0] == 0x99
     assert not sent[0].is_extended_id
+
+
+def test_main_logs_reset_after_setup_failure(tmp_path, caplog):
+    caplog.set_level(logging.INFO)
+    log_file = tmp_path / "can.log"
+    with patch(
+        "can_monitor.setup_interface", side_effect=[RuntimeError("boom"), None]
+    ), patch("can_monitor.monitor", side_effect=KeyboardInterrupt), patch(
+        "can_monitor.can.interface.Bus"
+    ) as bus_cls, patch("time.sleep"):
+        bus_cls.return_value.__enter__.return_value = object()
+        ret = main(["--log", str(log_file)])
+    assert ret == 0
+    assert "CAN interface reset and up" in caplog.text
+
+
+def test_main_exits_after_max_failures(tmp_path, caplog):
+    caplog.set_level(logging.INFO)
+    log_file = tmp_path / "can.log"
+    with patch("can_monitor.setup_interface", side_effect=RuntimeError("boom")), patch(
+        "time.sleep"
+    ):
+        ret = main(["--log", str(log_file)])
+    assert ret == 1
+    assert "Exceeded maximum consecutive CAN errors" in caplog.text


### PR DESCRIPTION
## Summary
- track consecutive CAN bus errors and setup failures
- stop after three unsuccessful attempts with a fatal log
- log CAN interface recovery at INFO and reset counter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a2ec61c7083248542e30e84133e92