### PR TITLE
Handle UDS security lockout

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -193,6 +193,7 @@ def _process_uds_payload(
             state["uds_locked_out"] = True
             global uds_locked_out
             uds_locked_out = True
+            logger.warning("UDS security access locked out; further attempts disabled")
         if nrc == 0x78:
             # signal to the caller that a final response is pending
             state["pending"] = True
@@ -401,9 +402,13 @@ def _sequence_loop(
     while not stop_event.is_set():
         start = time.time()
         for step in sequence:
+            data = bytes.fromhex(step["payload"])
+            if uds_locked_out and data and data[0] == 0x27:
+                logger.warning("Skipping security access due to lockout")
+                continue
             msg = can.Message(
                 arbitration_id=step["can_id"],
-                data=bytes.fromhex(step["payload"]),
+                data=data,
                 is_extended_id=bool(step.get("is_extended_id", step["can_id"] > 0x7FF)),
             )
             bus.send(msg)

--- a/tests/test_dtc_parsing.py
+++ b/tests/test_dtc_parsing.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-import can_monitor
-from can_monitor import _process_uds_payload
+import can_monitor  # noqa: E402
+from can_monitor import _process_uds_payload  # noqa: E402
 
 
 def test_process_uds_payload_parses_dtc(caplog):
@@ -31,14 +31,18 @@ def test_process_uds_payload_parses_dtc(caplog):
 
 
 @pytest.mark.parametrize("nrc", [0x36, 0x37])
-def test_process_uds_payload_sets_locked_out(nrc):
+def test_process_uds_payload_sets_locked_out(nrc, caplog):
     can_monitor.uds_locked_out = False
     state = {}
     payload = bytes([0x7F, 0x27, nrc])
     logger = logging.getLogger("test")
-    _process_uds_payload(payload, state, {}, logger)
+    with caplog.at_level(logging.WARNING):
+        _process_uds_payload(payload, state, {}, logger)
     assert state.get("uds_locked_out") is True
     assert can_monitor.uds_locked_out is True
+    assert "locked out" in caplog.text.lower()
+
+
 def test_ignore_p0000(caplog):
     payload = bytes.fromhex("59 02 FF 00 00 00 10")
     state = {}

--- a/tests/test_sequence_scheduler.py
+++ b/tests/test_sequence_scheduler.py
@@ -11,6 +11,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from can_monitor import _sequence_loop  # noqa: E402
+import can_monitor  # noqa: E402
 
 
 def test_sequence_interval(monkeypatch, bus_factory):
@@ -85,3 +86,21 @@ def test_sequence_multiframe(monkeypatch, bus_factory):
     stop.set()
     t.join()
     assert any(m.data[0] == 0x30 for m in sent)
+
+
+def test_sequence_skips_security_access_when_locked_out(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
+    sent: list[can.Message] = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+    can_monitor.uds_locked_out = True
+    stop = threading.Event()
+    seq = [{"can_id": 0x123, "payload": "2701"}]
+    t = threading.Thread(
+        target=_sequence_loop,
+        args=(bus, seq, 20, None, logging.getLogger("test"), stop),
+    )
+    t.start()
+    time.sleep(0.05)
+    stop.set()
+    t.join()
+    assert not sent


### PR DESCRIPTION
## Summary
- log UDS security lockout on NRC 0x36/0x37 and set a module-level flag
- skip security access steps while locked out
- test NRC 0x36/0x37 lockout handling and sequence skipping

## Testing
- `pre-commit run --files src/can_monitor.py tests/test_dtc_parsing.py tests/test_sequence_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_689ad405efec83249cd160f53592f0ec