### PR TITLE
Handle incomplete DTC bytes and extend DTC tests

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -144,10 +144,13 @@ def load_opendbc_dbs(bus: "can.BusABC") -> tuple[Optional[Database], list[Databa
     return None, fallback_dbs
 
 
-def _convert_to_pcode(code_bytes: bytes) -> str:
-    """Convert three raw DTC bytes to standard Pxxxx style code."""
+def _convert_to_pcode(code_bytes: bytes) -> Optional[str]:
+    """Convert raw DTC bytes to standard Pxxxx style code.
+
+    Returns ``None`` if fewer than two bytes are provided.
+    """
     if len(code_bytes) < 2:
-        return "P0000"
+        return None
     value = (code_bytes[0] << 8) | code_bytes[1]
     letter_map = {0: "P", 1: "C", 2: "B", 3: "U"}
     letter = letter_map.get((value >> 14) & 0x3, "P")
@@ -216,7 +219,7 @@ def _process_uds_payload(
         for i in range(dtc_count):
             start = i * 4
             code = _convert_to_pcode(entries[start : start + 3])  # noqa: E203
-            if code == "P0000":
+            if code is None or code == "P0000":
                 continue
             info = uds_config.get("dtcs", {}).get(code)
             if info:

--- a/tests/test_dtc_parsing.py
+++ b/tests/test_dtc_parsing.py
@@ -8,7 +8,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 import can_monitor  # noqa: E402
-from can_monitor import _process_uds_payload  # noqa: E402
+from can_monitor import _process_uds_payload, _convert_to_pcode  # noqa: E402
 
 
 def test_process_uds_payload_parses_dtc(caplog):
@@ -52,6 +52,18 @@ def test_ignore_p0000(caplog):
     assert caplog.text == ""
 
 
+def test_empty_payload(caplog):
+    state = {}
+    logger = logging.getLogger("test")
+    with caplog.at_level(logging.INFO):
+        _process_uds_payload(b"", state, {}, logger)
+    assert caplog.text == ""
+
+
+def test_convert_to_pcode_insufficient_bytes():
+    assert _convert_to_pcode(b"\x12") is None
+
+
 def test_unknown_dtc_logged_once(caplog):
     payload = bytes.fromhex("59 02 FF 12 34 00 10")
     state = {}
@@ -59,6 +71,7 @@ def test_unknown_dtc_logged_once(caplog):
     with caplog.at_level(logging.INFO):
         _process_uds_payload(payload, state, {}, logger)
     assert "P1234" in caplog.text
+    assert caplog.records[0].levelname == "INFO"
 
     caplog.clear()
     # Clear DTCs to allow re-logging at debug on reappearance
@@ -69,7 +82,7 @@ def test_unknown_dtc_logged_once(caplog):
     caplog.clear()
     with caplog.at_level(logging.DEBUG):
         _process_uds_payload(payload, state, {}, logger)
-    assert "P1234" in caplog.text
+    assert any(r.levelname == "DEBUG" and "P1234" in r.message for r in caplog.records)
     assert "DTC set unchanged" not in caplog.text
 
 


### PR DESCRIPTION
## Summary
- Return `None` from `_convert_to_pcode` when fewer than two bytes are provided and skip such entries during UDS payload processing
- Expand DTC parsing tests with cases for empty payloads, unknown code logging levels, and validation of `_convert_to_pcode`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ad8cbc4c883248dbaa2e660054779