### PR TITLE
Track active DTC alerts and add persistence test

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -165,6 +165,7 @@ def _process_uds_payload(
     logger: logging.Logger,
 ) -> None:
     """Parse a complete UDS payload containing DTC information."""
+    active_alerts = state.setdefault("active_alerts", set())
     if not payload:
         return
     # negative response handling
@@ -211,7 +212,6 @@ def _process_uds_payload(
         dtc_count = len(entries) // 4
 
         seen_unknown = state.setdefault("seen_unknown_dtcs", set())
-        active_alerts = state.setdefault("active_alerts", set())
         parsed: list[dict[str, Any]] = []
         current_codes: set[str] = set()
         current_alerts: set[str] = set()

--- a/tests/test_dtc_parsing.py
+++ b/tests/test_dtc_parsing.py
@@ -4,6 +4,7 @@ import pytest
 
 import sys
 from pathlib import Path
+from typing import Any
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -115,6 +116,49 @@ def test_alert_only_on_change(caplog):
     caplog.clear()
     with caplog.at_level(logging.ERROR):
         _process_uds_payload(payload, state, uds_config, logger)
+    assert caplog.text.count("ALERT") == 1
+
+
+def test_persistent_alert_ignores_other_dtc_changes(caplog):
+    critical_only = bytes.fromhex("59 02 FF 05 8D 00 10")
+    with_extra = bytes.fromhex("59 02 FF 05 8D 00 10 12 34 00 10")
+    clear = bytes.fromhex("59 02 FF")
+    state: dict[str, Any] = {}
+    uds_config = {
+        "dtcs": {
+            "P058D": {
+                "description": "Dual Aux communication failure",
+                "severity": "CRITICAL",
+                "alert": True,
+                "component": "AUX",
+            },
+            "P1234": {
+                "description": "Example DTC",
+                "severity": "MAJOR",
+                "component": "MISC",
+            },
+        }
+    }
+    logger = logging.getLogger("test")
+
+    with caplog.at_level(logging.ERROR):
+        _process_uds_payload(critical_only, state, uds_config, logger)
+    assert caplog.text.count("ALERT") == 1
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        _process_uds_payload(with_extra, state, uds_config, logger)
+    assert "ALERT" not in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        _process_uds_payload(critical_only, state, uds_config, logger)
+    assert "ALERT" not in caplog.text
+
+    _process_uds_payload(clear, state, uds_config, logger)
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        _process_uds_payload(critical_only, state, uds_config, logger)
     assert caplog.text.count("ALERT") == 1
 
 


### PR DESCRIPTION
## Summary
- Initialize and maintain an `active_alerts` set in `_process_uds_payload` to suppress repeated critical DTC alerts until cleared.
- Add a dedicated test ensuring persistent critical DTCs only emit a single alert even when other DTCs change.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ada1fbf9883248f741b5286febf53