### PR TITLE
Serialize CAN bus access

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -46,6 +46,7 @@ except ImportError:
 
 
 uds_locked_out = False
+bus_lock = threading.Lock()
 
 
 def apply_patches(bus: "can.BusABC", patches: dict[str, Any]) -> None:
@@ -349,7 +350,8 @@ def _handle_uds_frame(
                 data=fc_data,
                 is_extended_id=bool(ecu_req_id and ecu_req_id > 0x7FF),
             )
-            bus.send(fc)
+            with bus_lock:
+                bus.send(fc)
         return True
     if frame_type == 0x2 and state.get("expected", 0) > 0:  # consecutive frame
         seq = pci & 0x0F
@@ -384,7 +386,8 @@ def _handle_uds_frame(
                     data=fc_data,
                     is_extended_id=bool(ecu_req_id and ecu_req_id > 0x7FF),
                 )
-                bus.send(fc)
+                with bus_lock:
+                    bus.send(fc)
             state["bs_count"] = 0
         return True
     return False
@@ -414,7 +417,8 @@ def _sequence_loop(
                 data=data,
                 is_extended_id=bool(step.get("is_extended_id", step["can_id"] > 0x7FF)),
             )
-            bus.send(msg)
+            with bus_lock:
+                bus.send(msg)
             resp_id = step.get("response_id")
             if resp_id is not None:
                 timeout = step.get("timeout_ms", 100) / 1000
@@ -423,7 +427,8 @@ def _sequence_loop(
                 state["payload"] = bytearray()
                 while time.time() < end_time and not stop_event.is_set():
                     remaining = end_time - time.time()
-                    rsp = bus.recv(timeout=remaining)
+                    with bus_lock:
+                        rsp = bus.recv(timeout=remaining)
                     if not rsp or rsp.arbitration_id != resp_id:
                         continue
                     if (
@@ -508,7 +513,8 @@ def monitor(
         flow_st = uds_config.get("flow_control", {}).get("st_min_ms", 0)
     try:
         while True:
-            msg = bus.recv(timeout=1.0)
+            with bus_lock:
+                msg = bus.recv(timeout=1.0)
             if msg is None:
                 if is_bus_off(bus):
                     record_bus_error()
@@ -751,6 +757,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                             source_address=uds_cfg.get("source_address"),
                             target_address=uds_cfg.get("target_address"),
                             address_extension=uds_cfg.get("address_extension"),
+                            bus_lock=bus_lock,
                         )
                         sess = uds_cfg.get("session")
                         if sess is not None:

--- a/src/uds.py
+++ b/src/uds.py
@@ -158,6 +158,7 @@ class UDSClient:
         on_reset: "Callable[[], None] | None" = None,
         error_on_reset: bool = False,
         logger: logging.Logger = LOGGER,
+        bus_lock: threading.Lock | None = None,
     ) -> None:
         self.bus = bus
         self.req_id = req_id
@@ -177,6 +178,7 @@ class UDSClient:
         self.logger = logger
         self._rx_fc_status = 0
         self._lock = threading.Lock()
+        self.bus_lock = bus_lock
 
         if self.source_address is not None and self.target_address is not None:
             base = 0x18DA
@@ -187,6 +189,19 @@ class UDSClient:
                 (base << 16) | (self.source_address << 8) | self.target_address
             )
             self.is_extended_id = True
+
+    def _bus_send(self, msg: "can.Message", timeout: float | None = None) -> None:
+        if self.bus_lock:
+            with self.bus_lock:
+                self.bus.send(msg, timeout=timeout)
+        else:
+            self.bus.send(msg, timeout=timeout)
+
+    def _bus_recv(self, timeout: float | None = None) -> "can.Message | None":
+        if self.bus_lock:
+            with self.bus_lock:
+                return self.bus.recv(timeout)
+        return self.bus.recv(timeout)
 
     # ------------------------------------------------------------------
     # sending
@@ -220,7 +235,7 @@ class UDSClient:
                     is_extended_id=self.is_extended_id,
                     data=frame_data,
                 )
-                self.bus.send(frame, timeout=send_timeout)
+                self._bus_send(frame, timeout=send_timeout)
                 self.logger.debug("Sent Single Frame: %s", frame.data.hex())
                 if self.t_data and self.t_data.con:
                     self.t_data.con(True, None)
@@ -248,7 +263,7 @@ class UDSClient:
                 is_extended_id=self.is_extended_id,
                 data=ff_data,
             )
-            self.bus.send(ff, timeout=send_timeout)
+            self._bus_send(ff, timeout=send_timeout)
             self.logger.debug("Sent First Frame: total_len=%d", total_len)
 
             # wait for flow control
@@ -261,7 +276,7 @@ class UDSClient:
                     self.logger.error("No Flow Control frame received")
                     raise ISOTransportError("No Flow Control frame received")
                 wait_start = time.monotonic()
-                fc = self.bus.recv(remaining)
+                fc = self._bus_recv(remaining)
                 elapsed += time.monotonic() - wait_start
                 if not fc or fc.arbitration_id != self.resp_id:
                     continue
@@ -309,7 +324,7 @@ class UDSClient:
                             self.logger.error("Flow control timeout")
                             raise ISOTransportError("Flow control timeout")
                         wait_start = time.monotonic()
-                        fc = self.bus.recv(remaining)
+                        fc = self._bus_recv(remaining)
                         elapsed += time.monotonic() - wait_start
                         if not fc or fc.arbitration_id != self.resp_id:
                             continue
@@ -359,7 +374,7 @@ class UDSClient:
                     is_extended_id=self.is_extended_id,
                     data=cf_data,
                 )
-                self.bus.send(cf, timeout=send_timeout)
+                self._bus_send(cf, timeout=send_timeout)
                 self.logger.debug("Sent Consecutive Frame seq=%d", seq)
                 offset += len(chunk)
                 seq = (seq + 1) & 0x0F
@@ -402,7 +417,7 @@ class UDSClient:
             is_extended_id=self.is_extended_id,
             data=data,
         )
-        self.bus.send(fc)
+        self._bus_send(fc)
         self.logger.debug(
             "Sent Flow Control: status=%d bs=%d st_min=%d",
             status,
@@ -433,7 +448,7 @@ class UDSClient:
             if remaining <= 0:
                 self.logger.error("UDS response timeout")
                 raise ISOTransportError("UDS response timeout")
-            msg = self.bus.recv(remaining)
+            msg = self._bus_recv(remaining)
             if not msg or msg.arbitration_id != self.resp_id:
                 continue
             data = bytes(msg.data)
@@ -550,22 +565,16 @@ class UDSClient:
             send_to, recv_to = timeout
         else:
             send_to = recv_to = timeout
-        self.logger.debug(
-            "Sending service 0x%02X with payload %s", service, data.hex()
-        )
+        self.logger.debug("Sending service 0x%02X with payload %s", service, data.hex())
         self._send(service, data, send_to)
         start = time.monotonic()
         while True:
             remaining = recv_to - (time.monotonic() - start)
             rsp = self._receive(remaining)
-            self.logger.debug(
-                "Response for service 0x%02X: %s", service, rsp.hex()
-            )
+            self.logger.debug("Response for service 0x%02X: %s", service, rsp.hex())
             if len(rsp) >= 3 and rsp[0] == 0x7F and rsp[2] == 0x78:
                 # NRC 0x78: response pending, wait for final response
-                self.logger.info(
-                    "Service 0x%02X pending (NRC 0x78)", service
-                )
+                self.logger.info("Service 0x%02X pending (NRC 0x78)", service)
                 continue
             if len(rsp) >= 3 and rsp[0] == 0x7F:
                 code = rsp[2]
@@ -655,9 +664,7 @@ class UDSClient:
                 _nrc_desc(code),
             )
         else:
-            self.logger.error(
-                "Unexpected response to session change: %s", rsp.hex()
-            )
+            self.logger.error("Unexpected response to session change: %s", rsp.hex())
         return False
 
     def security_access(

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 import uuid
+import queue
 from unittest.mock import patch
 
 import can
@@ -14,14 +15,14 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-import can_monitor
-from can_monitor import (
+import can_monitor  # noqa: E402
+from can_monitor import (  # noqa: E402
     load_dbc,
     load_opendbc_dbs,
     monitor,
     apply_patches,
     main,
-)  # noqa: E402
+)
 from metrics import get_metrics, reset_metrics  # noqa: E402
 
 if not hasattr(can.bus.BusState, "BUS_OFF"):
@@ -91,7 +92,11 @@ def _run_main_with_key(monkeypatch, tmp_path, key_cfg):
             return None
 
     monkeypatch.setattr(can_monitor, "setup_interface", lambda *a, **k: None)
-    monkeypatch.setattr(can_monitor, "monitor", lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()))
+    monkeypatch.setattr(
+        can_monitor,
+        "monitor",
+        lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
     monkeypatch.setattr(can.interface, "Bus", lambda *a, **k: DummyBus())
     monkeypatch.setattr(can_monitor, "UDSClient", DummyClient)
 
@@ -376,6 +381,78 @@ def test_apply_patches_sends_and_logs(caplog, bus_factory):
         with patch.object(bus, "recv", side_effect=fake_recv):
             apply_patches(bus, patches)
     assert "Patch 'demo' applied" in caplog.text
+
+
+def test_no_cf_sequence_warning_with_concurrent_access(log_setup):
+    logger, log_file = log_setup
+
+    class DummyBus:
+        def __init__(self) -> None:
+            self.recv_queue: "queue.Queue[can.Message | str]" = queue.Queue()
+            self.sent: "queue.Queue[can.Message]" = queue.Queue()
+
+        def send(self, msg, timeout=None):  # pragma: no cover - simple stub
+            self.sent.put(msg)
+
+        def recv(self, timeout=None):
+            try:
+                item = self.recv_queue.get(timeout=timeout)
+                if item == "error":
+                    raise can.CanError("stop")
+                return item
+            except queue.Empty:
+                return None
+
+    bus = DummyBus()
+    uds_cfg = {
+        "ecu_request_id": 0x123,
+        "ecu_response_id": 0x456,
+        "flow_control": {"block_size": 0, "st_min_ms": 0},
+    }
+    sequence = [
+        {
+            "can_id": 0x123,
+            "payload": "01",
+            "response_id": 0x456,
+            "timeout_ms": 200,
+        }
+    ]
+
+    def run_monitor() -> None:
+        try:
+            monitor(
+                bus,
+                None,
+                logger,
+                uds_config=uds_cfg,
+                sequence=sequence,
+                interval_ms=50,
+            )
+        except can.CanError:
+            pass
+
+    t = threading.Thread(target=run_monitor)
+    t.start()
+    bus.sent.get(timeout=1)
+
+    first = can.Message(
+        arbitration_id=0x456,
+        data=bytes([0x10, 0x0A, 1, 2, 3, 4, 5, 6]),
+        is_extended_id=False,
+    )
+    cf = can.Message(
+        arbitration_id=0x456,
+        data=bytes([0x21, 7, 8, 9, 10, 0, 0, 0]),
+        is_extended_id=False,
+    )
+
+    bus.recv_queue.put(first)
+    bus.recv_queue.put(cf)
+    bus.recv_queue.put("error")
+
+    t.join()
+    contents = log_file.read_text()
+    assert "Unexpected CF sequence" not in contents
 
 
 def test_load_dbc_missing_file(caplog):
@@ -765,7 +842,9 @@ def test_main_logs_reset_after_setup_failure(tmp_path, caplog):
         "can_monitor.setup_interface", side_effect=[RuntimeError("boom"), None]
     ), patch("can_monitor.monitor", side_effect=KeyboardInterrupt), patch(
         "can_monitor.can.interface.Bus"
-    ) as bus_cls, patch("time.sleep"):
+    ) as bus_cls, patch(
+        "time.sleep"
+    ):
         bus_cls.return_value.__enter__.return_value = object()
         ret = main(["--log", str(log_file)])
     assert ret == 0


### PR DESCRIPTION
## Summary
- add global bus lock and wrap bus.send/bus.recv to prevent concurrent access
- allow UDSClient to use shared lock for thread-safe ISO-TP operations
- test concurrent traffic to ensure CF sequence warnings are suppressed

## Testing
- `pre-commit run --files src/can_monitor.py src/uds.py tests/test_can_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_689adc4aae0c83249e621ff562d875f2