### PR TITLE
docs: recommend higher st_min_ms for Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,14 @@ diagnostic trouble code (DTC) metadata and ISO-TP flow control options.
         "component": "PS"
       }
     },
-    "flow_control": {"block_size": 0, "st_min_ms": 0}
+    "flow_control": {"block_size": 0, "st_min_ms": 5}
   }
 }
 ```
+
+On resource-constrained boards like the Raspberry Pi, a non-zero
+`st_min_ms` (typically 5–10 ms) helps account for scheduling jitter and
+ensures reliable transfers.
 
 The security `key` may also be supplied as a list of byte values:
 
@@ -190,7 +194,9 @@ Normal-fixed, mixed and extended addressing modes are supported:
 #### Flow Control Tuning
 
 The block size and minimum separation time advertised in Flow Control frames can
-be adjusted to trade throughput for bus load or apply throttling.
+be adjusted to trade throughput for bus load or apply throttling.  On
+Raspberry Pi hardware, using an `st_min_ms` of roughly 5–10 ms helps avoid
+missing consecutive frames due to OS scheduling latency.
 
 ```python
 # Maximise throughput

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -87,9 +87,10 @@ Additional options:
 
 `uds_config.json` combines the startup sequence with UDS options.  The
 ``sequence`` section issues the extended-session request, security seed/key
-exchange, DTC read and a flow-control frame.  The security block supports an
-optional ``algorithm`` entry referencing a callable or ``module:attr`` string
-used to derive the access key.
+exchange, DTC read and a flow-control frame.  On Raspberry Pi systems, set
+``flow_control.st_min_ms`` to around 5–10 ms to account for scheduler jitter.
+The security block supports an optional ``algorithm`` entry referencing a
+callable or ``module:attr`` string used to derive the access key.
 
 To troubleshoot ISO-TP segmentation, ``UDSClient`` supports standard Python
 logging. Create a logger and pass it to the client to view debug output:

--- a/docs/VCU_UDS_COMMUNICATION.md
+++ b/docs/VCU_UDS_COMMUNICATION.md
@@ -52,12 +52,13 @@ abort diagnostic polling.
 
 Large responses are segmented using ISO‑TP.  The receiver advertises its
 capabilities with a Flow Control (FC) frame.  For the VCU, a CTS frame
-`30 01 01 00 00 00 00 00` permits the sender to transmit one consecutive frame at
-a time (`block_size` = 1) with a minimum separation of 1 ms (`st_min_ms` = 1).
-These defaults are configurable in the JSON file:
+`30 01 05 00 00 00 00 00` permits the sender to transmit one consecutive frame at
+a time (`block_size` = 1) with a minimum separation of 5 ms (`st_min_ms` = 5).
+On Raspberry Pi hardware, increasing `st_min_ms` to 5–10 ms helps prevent missed
+frames due to scheduling jitter. These defaults are configurable in the JSON file:
 
 ```json
-"flow_control": { "block_size": 1, "st_min_ms": 1 }
+"flow_control": { "block_size": 1, "st_min_ms": 5 }
 ```
 
 If the VCU responds with an FC status **WAIT** (0x1) transmission pauses but the
@@ -132,7 +133,7 @@ control parameters used by the monitor:
   "address_extension": null,
   "session": 3,
   "security": { "level": 1, "key": null },
-  "flow_control": { "block_size": 1, "st_min_ms": 1 },
+  "flow_control": { "block_size": 1, "st_min_ms": 5 },
   "dtcs": { ... }
 }
 ```
@@ -146,7 +147,8 @@ control parameters used by the monitor:
   instead of computing one, populate `security.key` with an 8‑byte hex string.
 * **Flow Control** – `block_size` and `st_min_ms` tune ISO‑TP reception.  Larger
   block sizes trade memory for throughput; a non‑zero `st_min_ms` throttles the
-  sender.
+  sender.  Raspberry Pi systems typically require `st_min_ms` of 5–10 ms to
+  reliably pace responses.
 * **DTC Mapping** – extend the `dtcs` dictionary with additional P‑codes as
   needed.  Each entry must include `description`, `severity` and `component`.  An
   optional `alert` flag promotes the code to a high‑priority log entry.
@@ -175,7 +177,8 @@ interacting with the VCU until restarted.
 1. **Add or modify DTCs** – edit `uds_config.json` and append new entries under
    `dtcs`.  Follow the existing schema.  Reload the monitor to apply.
 2. **Adjust flow control** – change `flow_control.block_size` or
-   `flow_control.st_min_ms` to tune throughput vs. bus load.
+   `flow_control.st_min_ms` to tune throughput vs. bus load.  When running on a
+   Raspberry Pi, values around 5–10 ms are typical.
 3. **Change security level or key** – set `security.level` and optionally provide
    a `security.key` for ECUs requiring a known key.
 4. **Alter session or CAN IDs** – modify `session`, `ecu_request_id` or

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -592,7 +592,7 @@ def test_uds_multi_block_fc(log_setup, bus_factory):
         uds_cfg = json.load(f)["uds"]
 
     uds_cfg["flow_control"]["block_size"] = 1
-    uds_cfg["flow_control"]["st_min_ms"] = 0
+    uds_cfg["flow_control"]["st_min_ms"] = 5
 
     payload = bytes([0x59, 0x02, 0x00] + [0] * 15)
     length = len(payload)
@@ -633,6 +633,7 @@ def test_uds_multi_block_fc(log_setup, bus_factory):
 
     fcs = [m for m in sent if m.data[0] == 0x30]
     assert len(fcs) == 2
+    assert all(m.data[2] == 5 for m in fcs)
 
 
 def test_uds_fc_extended_id(log_setup, bus_factory):

--- a/uds_config.json
+++ b/uds_config.json
@@ -8,7 +8,7 @@
     "source_address": 241,
     "target_address": 16,
     "address_extension": null,
-    "flow_control": { "block_size": 1, "st_min_ms": 1 },
+    "flow_control": { "block_size": 1, "st_min_ms": 5 },
     "security": {
       "level": 1,
       "key": [255, 255],
@@ -183,7 +183,7 @@
     {
       "name": "flow_control",
       "can_id": 2024,
-      "payload": "30 01 01 00 00 00 00 00",
+      "payload": "30 01 05 00 00 00 00 00",
       "response_id": null
     }
   ],


### PR DESCRIPTION
## Summary
- document that Raspberry Pi boards require a larger ISO-TP separation time and show how to configure it
- adjust default `uds_config.json` to use `st_min_ms` of 5 ms
- add test confirming Flow Control frames honour non-zero `st_min_ms`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689adeaf92108324a6cfd4d5e0d877d2