### PR TITLE
Handle sequence loop failures

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -416,51 +416,64 @@ def _sequence_loop(
     block = uds_config.get("flow_control", {}).get("block_size", 0) if uds_config else 0
     st_min = uds_config.get("flow_control", {}).get("st_min_ms", 0) if uds_config else 0
     state = {"expected": 0, "payload": bytearray()}
-    while not stop_event.is_set():
-        start = time.time()
-        for step in sequence:
-            data = bytes.fromhex(step["payload"])
-            if uds_locked_out and data and data[0] == 0x27:
-                logger.warning("Skipping security access due to lockout")
-                continue
-            msg = can.Message(
-                arbitration_id=step["can_id"],
-                data=data,
-                is_extended_id=bool(step.get("is_extended_id", step["can_id"] > 0x7FF)),
-            )
-            with bus_lock:
-                bus.send(msg)
-            resp_id = step.get("response_id")
-            if resp_id is not None:
-                timeout = step.get("timeout_ms", 100) / 1000
-                end_time = time.time() + timeout
-                state["expected"] = 0
-                state["payload"] = bytearray()
-                while time.time() < end_time and not stop_event.is_set():
-                    remaining = end_time - time.time()
-                    with bus_lock:
-                        rsp = bus.recv(timeout=remaining)
-                    if not rsp or rsp.arbitration_id != resp_id:
-                        continue
-                    if (
-                        _handle_uds_frame(
-                            bus,
-                            rsp,
-                            state,
-                            step["can_id"],
-                            block,
-                            st_min,
-                            uds_config or {},
-                            logger,
+    try:
+        while not stop_event.is_set():
+            start = time.time()
+            for step in sequence:
+                data = bytes.fromhex(step["payload"])
+                if uds_locked_out and data and data[0] == 0x27:
+                    logger.warning("Skipping security access due to lockout")
+                    continue
+                msg = can.Message(
+                    arbitration_id=step["can_id"],
+                    data=data,
+                    is_extended_id=bool(
+                        step.get("is_extended_id", step["can_id"] > 0x7FF)
+                    ),
+                )
+                with bus_lock:
+                    bus.send(msg)
+                resp_id = step.get("response_id")
+                if resp_id is not None:
+                    timeout = step.get("timeout_ms", 100) / 1000
+                    end_time = time.time() + timeout
+                    state["expected"] = 0
+                    state["payload"] = bytearray()
+                    received = False
+                    while time.time() < end_time and not stop_event.is_set():
+                        remaining = end_time - time.time()
+                        with bus_lock:
+                            rsp = bus.recv(timeout=remaining)
+                        if not rsp or rsp.arbitration_id != resp_id:
+                            continue
+                        if (
+                            _handle_uds_frame(
+                                bus,
+                                rsp,
+                                state,
+                                step["can_id"],
+                                block,
+                                st_min,
+                                uds_config or {},
+                                logger,
+                            )
+                            and state.get("expected", 0) <= 0
+                            and not state.pop("pending", False)
+                        ):
+                            received = True
+                            break
+                    if not received:
+                        logger.warning(
+                            "No response to '%s' request",
+                            step.get("name", hex(step["can_id"])),
                         )
-                        and state.get("expected", 0) <= 0
-                        and not state.pop("pending", False)
-                    ):
-                        break
-        elapsed = (time.time() - start) * 1000
-        wait_ms = interval_ms - elapsed
-        if wait_ms > 0:
-            stop_event.wait(wait_ms / 1000)
+            elapsed = (time.time() - start) * 1000
+            wait_ms = interval_ms - elapsed
+            if wait_ms > 0:
+                stop_event.wait(wait_ms / 1000)
+    except Exception:
+        logger.error("Sequence loop error", exc_info=True)
+        stop_event.set()
 
 
 def monitor(

--- a/tests/test_sequence_scheduler.py
+++ b/tests/test_sequence_scheduler.py
@@ -104,3 +104,57 @@ def test_sequence_skips_security_access_when_locked_out(monkeypatch, bus_factory
     stop.set()
     t.join()
     assert not sent
+
+
+def test_sequence_loop_exception_stops_thread(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
+
+    def fail_send(msg, timeout=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(bus, "send", fail_send)
+    stop = threading.Event()
+    seq = [{"can_id": 0x123, "payload": "00"}]
+    logger = logging.getLogger("seq")
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        t = threading.Thread(
+            target=_sequence_loop, args=(bus, seq, 20, None, logger, stop)
+        )
+        t.start()
+        t.join(timeout=1)
+    assert stop.is_set()
+    assert not t.is_alive()
+    assert any("Sequence loop error" in r.getMessage() for r in caplog.records)
+
+
+def test_sequence_loop_timeout_warns(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: None)
+
+    def no_resp(timeout):
+        time.sleep(timeout)
+        return None
+
+    monkeypatch.setattr(bus, "recv", no_resp)
+    stop = threading.Event()
+    seq = [
+        {
+            "name": "ping",
+            "can_id": 0x123,
+            "payload": "00",
+            "response_id": 0x321,
+            "timeout_ms": 10,
+        }
+    ]
+    logger = logging.getLogger("seq")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        t = threading.Thread(
+            target=_sequence_loop, args=(bus, seq, 100, None, logger, stop)
+        )
+        t.start()
+        time.sleep(0.05)
+        stop.set()
+        t.join()
+    assert any(
+        "No response to 'ping' request" in r.getMessage() for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- stop sequence thread on unexpected errors
- warn when a request expecting a response times out
- test sequence loop error handling and timeouts

## Testing
- `pre-commit run --files src/can_monitor.py tests/test_sequence_scheduler.py`
- `pytest tests/test_sequence_scheduler.py::test_sequence_loop_exception_stops_thread tests/test_sequence_scheduler.py::test_sequence_loop_timeout_warns -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae22e7c508324b32d52085835caec