### PR TITLE
Handle CAN errors in patch application

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -58,8 +58,12 @@ def apply_patches(bus: "can.BusABC", patches: dict[str, Any]) -> None:
             is_extended_id=False,
         )
         for _ in range(p.get("retries", 1)):
-            bus.send(msg, timeout=0.2)
-            rsp = bus.recv(timeout=p.get("timeout_ms", 300) / 1000)
+            try:
+                bus.send(msg, timeout=0.2)
+                rsp = bus.recv(timeout=p.get("timeout_ms", 300) / 1000)
+            except can.CanError as exc:
+                logging.warning("Patch '%s' failed – CAN error: %s", name, exc)
+                break
             if rsp and rsp.arbitration_id == p["response_id"]:
                 logging.info("Patch '%s' applied (got 0x%02X)", name, rsp.data[0])
                 break

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -425,6 +425,30 @@ def test_apply_patches_sends_and_logs(caplog, bus_factory):
     assert "Patch 'demo' applied" in caplog.text
 
 
+def test_apply_patches_can_error_logs_warning(caplog, bus_factory):
+    bus = bus_factory(bitrate=500000)
+    patches = {
+        "demo": {
+            "can_id": 0x123,
+            "payload": "01",
+            "response_id": 0x456,
+            "timeout_ms": 100,
+            "retries": 3,
+        }
+    }
+
+    with caplog.at_level(logging.WARNING):
+        with patch.object(bus, "send") as mock_send, patch.object(
+            bus, "recv", side_effect=can.CanError("boom")
+        ) as mock_recv:
+            apply_patches(bus, patches)
+
+    assert "Patch 'demo' failed" in caplog.text
+    assert "CAN error" in caplog.text
+    assert mock_send.call_count == 1
+    assert mock_recv.call_count == 1
+
+
 def test_no_cf_sequence_warning_with_concurrent_access(log_setup):
     logger, log_file = log_setup
 


### PR DESCRIPTION
## Summary
- wrap CAN patch send/recv operations with `can.CanError` handling and warnings
- add unit test verifying patch retries stop on CAN error

## Testing
- `pre-commit run --files src/can_monitor.py tests/test_can_monitor.py`
- `pytest tests/test_can_monitor.py::test_apply_patches_sends_and_logs tests/test_can_monitor.py::test_apply_patches_can_error_logs_warning -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae366c3b883248c9851ea9453a423