### PR TITLE
Restart flow-control timer and relax WAIT handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ be adjusted to trade throughput for bus load or apply throttling.  On
 Raspberry Pi hardware, using an `st_min_ms` of roughly 5–10 ms helps avoid
 missing consecutive frames due to OS scheduling latency.
 
+By default the client restarts the flow-control timer after each WAIT or CTS
+frame and allows up to `0xFF` consecutive WAIT frames before aborting.
+
 ```python
 # Maximise throughput
 client = UDSClient(bus, 0x7E0, 0x7E8, rx_block_size=0, rx_st_min=0)
@@ -207,6 +210,9 @@ client = UDSClient(bus, 0x7E0, 0x7E8, rx_block_size=1, rx_st_min=20)
 
 # Protect against oversized responses
 client = UDSClient(bus, 0x7E0, 0x7E8, max_rx_size=1024)
+
+# Allow unlimited Flow Control WAIT frames (default)
+client = UDSClient(bus, 0x7E0, 0x7E8)
 
 # Permit a single Flow Control WAIT before aborting
 client = UDSClient(bus, 0x7E0, 0x7E8, wft_max=1)

--- a/src/uds.py
+++ b/src/uds.py
@@ -110,7 +110,8 @@ class UDSClient:
         control frames.
     wft_max: int, optional
         Maximum number of consecutive Flow Control WAIT frames permitted
-        before aborting.  Default ``0`` per ISO-15765-2.
+        before aborting.  Default ``0xFF`` to allow indefinite WAIT frames
+        while relying on the N_Bs timeout.
         key_algo: callable or ``module:attr`` string, optional
         Function applied to the received seed to generate the security
         access key. When ``None`` a default inversion-based algorithm is
@@ -148,7 +149,7 @@ class UDSClient:
         is_extended_id: bool = False,
         rx_block_size: int = 0,
         rx_st_min: int = 0,
-        wft_max: int = 0,
+        wft_max: int = 0xFF,
         key_algo: "Callable[[bytes], bytes] | str | None" = None,
         source_address: "int | None" = None,
         target_address: "int | None" = None,
@@ -268,16 +269,14 @@ class UDSClient:
 
             # wait for flow control
             self.logger.debug("Waiting for Flow Control frame")
-            elapsed = 0.0
             wait_count = 0
+            fc_start = time.monotonic()
             while True:
-                remaining = fc_timeout - elapsed
+                remaining = fc_timeout - (time.monotonic() - fc_start)
                 if remaining <= 0:
                     self.logger.error("No Flow Control frame received")
                     raise ISOTransportError("No Flow Control frame received")
-                wait_start = time.monotonic()
                 fc = self._bus_recv(remaining)
-                elapsed += time.monotonic() - wait_start
                 if not fc or fc.arbitration_id != self.resp_id:
                     continue
                 data_fc = bytes(fc.data)
@@ -301,12 +300,14 @@ class UDSClient:
                         st_delay,
                     )
                     wait_count = 0
+                    fc_start = time.monotonic()
                     break
                 wait_count += 1
                 self.logger.debug("Flow Control WAIT received (%d)", wait_count)
                 if wait_count > self.wft_max:
                     self.logger.error("Flow control WAIT limit exceeded")
                     raise ISOTransportError("Too many Flow Control WAIT frames")
+                fc_start = time.monotonic()
             seq = 1
             offset = first_len
             sent_in_block = 0
@@ -318,14 +319,13 @@ class UDSClient:
                         block_size,
                     )
                     # need next flow control
+                    fc_start = time.monotonic()
                     while True:
-                        remaining = fc_timeout - elapsed
+                        remaining = fc_timeout - (time.monotonic() - fc_start)
                         if remaining <= 0:
                             self.logger.error("Flow control timeout")
                             raise ISOTransportError("Flow control timeout")
-                        wait_start = time.monotonic()
                         fc = self._bus_recv(remaining)
-                        elapsed += time.monotonic() - wait_start
                         if not fc or fc.arbitration_id != self.resp_id:
                             continue
                         data_fc = bytes(fc.data)
@@ -350,12 +350,14 @@ class UDSClient:
                             )
                             wait_count = 0
                             sent_in_block = 0
+                            fc_start = time.monotonic()
                             break
                         wait_count += 1
                         self.logger.debug("Flow Control WAIT received (%d)", wait_count)
                         if wait_count > self.wft_max:
                             self.logger.error("Flow control WAIT limit exceeded")
                             raise ISOTransportError("Too many Flow Control WAIT frames")
+                        fc_start = time.monotonic()
                 chunk = payload[offset : offset + chunk_len]  # noqa: E203
                 if self.address_extension is not None:
                     cf_data = (

--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -51,7 +51,7 @@ def test_send_segments_respects_flow_control(monkeypatch, bus_factory):
     assert sleeps and pytest.approx(sleeps[0], rel=0.1) == 0.001
 
 
-def test_send_cumulative_fc_timeout(monkeypatch, bus_factory):
+def test_send_restarts_fc_timeout(monkeypatch, bus_factory):
     bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)
 
@@ -85,8 +85,7 @@ def test_send_cumulative_fc_timeout(monkeypatch, bus_factory):
     monkeypatch.setattr(bus, "recv", fake_recv)
 
     data = bytes(range(14))
-    with pytest.raises(ISOTransportError, match="Flow control timeout"):
-        client.send(0x22, data, timeout=1.0)
+    assert client.send(0x22, data, timeout=1.0)
 
 
 def test_send_rejects_overly_large_payload(monkeypatch, bus_factory):
@@ -671,6 +670,55 @@ def test_send_wait_timeout(monkeypatch, bus_factory, caplog):
     assert any("Flow Control WAIT received" in r.message for r in caplog.records)
     assert any("No Flow Control frame received" in r.message for r in caplog.records)
 
+
+def test_send_multiple_waits_within_timeout(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
+    test_logger = logging.getLogger("uds_multiple_waits")
+    test_logger.setLevel(logging.DEBUG)
+    client = UDSClient(bus, 0x7E0, 0x7E8, logger=test_logger)
+
+    sent: list[can.Message] = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+
+    fc_wait = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x31, 0, 0, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    fc_cts = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x30, 0, 0, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+
+    events = [(0.6, fc_wait), (0.6, fc_wait), (0.6, fc_cts)]
+    now = [0.0]
+
+    def fake_monotonic() -> float:
+        return now[0]
+
+    def fake_recv(timeout):
+        if events:
+            delay, msg = events[0]
+            if delay > timeout:
+                now[0] += timeout
+                events[0] = (delay - timeout, msg)
+                return None
+            now[0] += delay
+            events.pop(0)
+            return msg
+        now[0] += timeout
+        return None
+
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(bus, "recv", fake_recv)
+
+    with caplog.at_level(logging.DEBUG, logger="uds_multiple_waits"):
+        assert client.send(0x22, bytes(range(10)), timeout=1.0)
+
+    wait_logs = [r for r in caplog.records if "Flow Control WAIT received" in r.message]
+    assert len(wait_logs) == 2
+    assert len(sent) == 2
 
 def test_send_wait_overflow(monkeypatch, bus_factory):
     bus = bus_factory(bitrate=500000)


### PR DESCRIPTION
## Summary
- restart the flow-control timeout after each WAIT or CTS frame so N_Bs is measured per ISO
- default wft_max to 0xFF and document the permissive behavior
- add regression tests covering multiple WAIT frames and restarting N_Bs after CTS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aedecf0608324b68ba87f4111e5bf