### PR TITLE
Add configurable pad byte to UDSClient

### DIFF
--- a/src/uds.py
+++ b/src/uds.py
@@ -139,8 +139,15 @@ class UDSClient:
     n_cr: float, optional
         Maximum number of seconds to wait for the next response frame before
         declaring a timeout.  This timer restarts after every received frame.
-    logger: logging.Logger, optional
+        logger: logging.Logger, optional
         Logger used for debug output.  Defaults to a module-level logger.
+    bus_lock: threading.Lock, optional
+        Lock used to serialize access to the CAN bus when shared.
+    can_fd: bool, optional
+        Use CAN FD frames with 64-byte payloads.  Default ``False``.
+    pad_byte: int, optional
+        Byte value used to pad unused space in Single, First and
+        Consecutive frames.  Defaults to ``0x00``.
     """
 
     def __init__(
@@ -165,6 +172,7 @@ class UDSClient:
         logger: logging.Logger = LOGGER,
         bus_lock: threading.Lock | None = None,
         can_fd: bool = False,
+        pad_byte: int = 0x00,
     ) -> None:
         self.bus = bus
         self.req_id = req_id
@@ -187,6 +195,7 @@ class UDSClient:
         self._lock = threading.Lock()
         self.bus_lock = bus_lock
         self.can_fd = can_fd
+        self.pad_byte = pad_byte & 0xFF
 
         if self.source_address is not None and self.target_address is not None:
             base = 0x18DA
@@ -243,7 +252,7 @@ class UDSClient:
                     + pci
                     + payload
                 )
-                frame_data += bytes(dlc - len(frame_data))
+                frame_data += bytes([self.pad_byte]) * (dlc - len(frame_data))
                 frame = can.Message(
                     arbitration_id=self.req_id,
                     is_extended_id=self.is_extended_id,
@@ -279,7 +288,7 @@ class UDSClient:
                 + pci
                 + first_payload
             )
-            ff_data += bytes(dlc - len(ff_data))
+            ff_data += bytes([self.pad_byte]) * (dlc - len(ff_data))
             ff = can.Message(
                 arbitration_id=self.req_id,
                 is_extended_id=self.is_extended_id,
@@ -385,7 +394,7 @@ class UDSClient:
                     cf_data = bytes([self.address_extension, 0x20 | (seq & 0x0F)]) + chunk
                 else:
                     cf_data = bytes([0x20 | (seq & 0x0F)]) + chunk
-                cf_data += bytes(dlc - len(cf_data))
+                cf_data += bytes([self.pad_byte]) * (dlc - len(cf_data))
                 cf = can.Message(
                     arbitration_id=self.req_id,
                     is_extended_id=self.is_extended_id,

--- a/tests/test_uds_client.py
+++ b/tests/test_uds_client.py
@@ -52,6 +52,47 @@ def test_send_segments_respects_flow_control(monkeypatch, bus_factory):
     assert sleeps and pytest.approx(sleeps[0], rel=0.1) == 0.001
 
 
+def test_send_single_frame_uses_pad_byte(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
+    client = UDSClient(bus, 0x7E0, 0x7E8, pad_byte=0xCC)
+
+    sent: list[can.Message] = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+
+    client.send(0x22, b"\xAA\xBB")
+
+    assert len(sent) == 1
+    # first byte length, then service + data => padding starts at index 4
+    assert bytes(sent[0].data)[4:] == bytes([0xCC]) * 4
+
+
+def test_send_consecutive_frame_uses_pad_byte(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
+    client = UDSClient(bus, 0x7E0, 0x7E8, pad_byte=0xAA)
+
+    sent: list[can.Message] = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+
+    fc = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x30, 1, 0, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    fcs = [fc, fc]
+
+    def fake_recv(timeout):
+        return fcs.pop(0)
+
+    monkeypatch.setattr(bus, "recv", fake_recv)
+
+    data = bytes(range(14))
+    client.send(0x22, data)
+
+    assert len(sent) == 3
+    # final CF carries two bytes of data -> padding begins at index 3
+    assert bytes(sent[2].data)[3:] == bytes([0xAA]) * 5
+
+
 def test_send_restarts_fc_timeout(monkeypatch, bus_factory):
     bus = bus_factory(bitrate=500000)
     client = UDSClient(bus, 0x7E0, 0x7E8)


### PR DESCRIPTION
## Summary
- allow choosing a pad byte for ISO-TP frames via new `pad_byte` option
- document pad byte usage in UDSClient
- test that single and consecutive frames use the configured pad byte

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af74c6b7483249dba352975647863