### PR TITLE
feat: add dynamic UDS security pre-test

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -89,8 +89,8 @@ Additional options:
 ``sequence`` section issues the extended-session request, security seed/key
 exchange, DTC read and a flow-control frame.  On Raspberry Pi systems, set
 ``flow_control.st_min_ms`` to around 5–10 ms to account for scheduler jitter.
-The security block supports an optional ``algorithm`` entry referencing a
-callable or ``module:attr`` string used to derive the access key.
+The security block accepts optional ``data_record`` bytes and an ``algorithm``
+reference (callable or ``module:attr`` string) used to derive the access key.
 
 To troubleshoot ISO-TP segmentation, ``UDSClient`` supports standard Python
 logging. Create a logger and pass it to the client to view debug output:

--- a/docs/VCU_UDS_COMMUNICATION.md
+++ b/docs/VCU_UDS_COMMUNICATION.md
@@ -20,10 +20,13 @@ UDSClient -> CAN bus -> VCU -> CAN bus -> UDSClient
 The typical sequence is:
 
 1. **Enter extended diagnostic session** – unlocks enhanced services.
-2. **Obtain and submit security access key** – required before protected
-   services such as DTC reading.
-3. **Read DTCs** – retrieve current Diagnostic Trouble Codes.
-4. **Flow control** – govern multi‑frame responses.
+2. **Request seed** – `06 27 01 01 01 00 00 00` includes a two‑byte data record.
+3. **Send derived key** – `06 27 02 01 <key_hi> <key_lo> 00 00 00` echoes the data
+   record and the algorithmically computed key.
+4. **Read DTCs** – two identical requests
+   `03 19 01 01 00 00 00 00` query the VCU.
+5. **Flow control** – each multi‑frame response is acknowledged with
+   `30 01 01 00 00 00 00 00`.
 
 Each step and the associated configuration are detailed below.
 
@@ -37,11 +40,17 @@ with `50 03` if the transition is successful.
 
 ### Security Access
 After the session switch the client requests security level 1.  The first
-request (`06 27 01 01 01 00 00 00`) asks the VCU for a seed.  The client then
-computes the corresponding key and submits it in a follow‑up `0x27` request.  The
-algorithm used to derive the key is pluggable: by default the seed bytes are
-bit‑wise inverted, but a custom function or ``module:attr`` string can be
-supplied in configuration under ``uds.security.algorithm``.
+request (`06 27 01 01 01 00 00 00`) asks the VCU for a seed.  Two additional
+bytes (`01 01`) act as a supplier‑defined *data record* and must be echoed when
+submitting the key.  The client derives the key from the received seed (and, if
+necessary, the data record) before issuing a follow‑up `0x27` request.
+
+The key algorithm is pluggable: by default the seed bytes are bit‑wise inverted.
+Custom algorithms or ``module:attr`` strings may be supplied via
+``uds.security.algorithm``.  For ECUs where the correct algorithm is unknown a
+pre‑test helper iterates over a list of candidate algorithms until the VCU
+accepts one, complying with the ISO‑15765‑2 requirement to request a new seed
+after each failed attempt.
 
 If the VCU does not answer with a positive response (`0x67`) or the computed key
 is rejected, :meth:`security_access` raises :class:`ISOTransportError` with the
@@ -52,13 +61,13 @@ abort diagnostic polling.
 
 Large responses are segmented using ISO‑TP.  The receiver advertises its
 capabilities with a Flow Control (FC) frame.  For the VCU, a CTS frame
-`30 01 05 00 00 00 00 00` permits the sender to transmit one consecutive frame at
-a time (`block_size` = 1) with a minimum separation of 5 ms (`st_min_ms` = 5).
+`30 01 01 00 00 00 00 00` permits the sender to transmit one consecutive frame at
+a time (`block_size` = 1) with a minimum separation of 1 ms (`st_min_ms` = 1).
 On Raspberry Pi hardware, increasing `st_min_ms` to 5–10 ms helps prevent missed
 frames due to scheduling jitter. These defaults are configurable in the JSON file:
 
 ```json
-"flow_control": { "block_size": 1, "st_min_ms": 5 }
+"flow_control": { "block_size": 1, "st_min_ms": 1 }
 ```
 
 If the VCU responds with an FC status **WAIT** (0x1) transmission pauses but the
@@ -68,8 +77,8 @@ If the VCU responds with an FC status **WAIT** (0x1) transmission pauses but the
 ## Diagnostic Trouble Code Retrieval
 
 Once security is unlocked the monitor issues
-`03 19 02 FF 00 00 00 00` to read all stored DTCs.  The VCU responds with a
-multi‑frame message containing a count and one or more 3‑byte DTC entries.  Each
+`03 19 01 01 00 00 00 00` twice to query stored DTCs.  The VCU responds with
+multi‑frame messages containing a count and one or more 3‑byte DTC entries.  Each
 code is decoded, mapped to metadata defined in the configuration and logged.
 Critical codes (those with `"alert": true`) trigger an explicit alert in the
 output.
@@ -131,9 +140,12 @@ control parameters used by the monitor:
   "source_address": 241,
   "target_address": 16,
   "address_extension": null,
-  "session": 3,
-  "security": { "level": 1, "key": null },
-  "flow_control": { "block_size": 1, "st_min_ms": 5 },
+  "security": {
+    "level": 1,
+    "data_record": [1, 1],
+    "algorithm": "security_algorithms:xor_invert"
+  },
+    "flow_control": { "block_size": 1, "st_min_ms": 1 },
   "dtcs": { ... }
 }
 ```
@@ -143,8 +155,11 @@ control parameters used by the monitor:
   `target_address` activates 29‑bit normal‑fixed addressing automatically.
 * **Session** – the `session` field selects the diagnostic session (3 = extended).
   The code automatically invokes `change_session` before other actions.
-* **Security** – `security.level` sets the access level.  To supply a fixed key
-  instead of computing one, populate `security.key` with an 8‑byte hex string.
+* **Security** – `security.level` sets the access level.  `security.data_record`
+  appends supplier‑specific bytes to the seed request and is echoed when
+  submitting the key.  `security.algorithm` names a callable used to derive the
+  key from the ECU's seed.  A static key may be provided via `security.key`
+  if the algorithm is known to be unnecessary.
 * **Flow Control** – `block_size` and `st_min_ms` tune ISO‑TP reception.  Larger
   block sizes trade memory for throughput; a non‑zero `st_min_ms` throttles the
   sender.  Raspberry Pi systems typically require `st_min_ms` of 5–10 ms to

--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -802,14 +802,27 @@ def main(argv: Optional[list[str]] = None) -> int:
                                 key = bytes.fromhex(key_cfg)
                             elif isinstance(key_cfg, list):
                                 key = bytes(key_cfg)
+                            dr_cfg = sec_cfg.get("data_record")
+                            data_record = (
+                                bytes(dr_cfg) if isinstance(dr_cfg, list) else b""
+                            )
                             try:
-                                client.security_access(level, key)
-                                logger.info("UDS security level %s unlocked", level)
+                                if data_record:
+                                    client.security_access(
+                                        level, key, data_record=data_record
+                                    )
+                                else:
+                                    client.security_access(level, key)
+                                logger.info(
+                                    "UDS security level %s unlocked", level
+                                )
                             except ISOTransportError as exc:
                                 logger.warning(
                                     "UDS security level %s denied: %s", level, exc
                                 )
-                                if any(code in str(exc) for code in ("0x36", "0x37")):
+                                if any(
+                                    code in str(exc) for code in ("0x36", "0x37")
+                                ):
                                     uds_locked_out = True
                     except Exception as exc:  # pragma: no cover - best effort
                         logger.warning("UDS initialisation failed: %s", exc)

--- a/src/security_algorithms.py
+++ b/src/security_algorithms.py
@@ -1,0 +1,53 @@
+"""Collection of simple seed-key derivation algorithms for UDS security access.
+
+The functions here accept the seed bytes provided by the ECU and an optional
+``data_record`` which may contain supplier specific selectors.  Each algorithm
+returns the key bytes to be echoed in the SecurityAccess request.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def xor_invert(seed: bytes, data_record: bytes = b"") -> bytes:
+    """Return the bitwise inversion of ``seed``.
+
+    ``data_record`` is ignored and only present for API compatibility.
+    """
+
+    return bytes((b ^ 0xFF) & 0xFF for b in seed)
+
+
+def add_rotate(seed: bytes, data_record: bytes = b"") -> bytes:
+    """Example 16-bit additive/rotate transform.
+
+    The seed is interpreted as a big endian 16-bit value.  A constant is added
+    then the value is rotated left by three bits.
+    """
+
+    if len(seed) < 2:
+        raise ValueError("seed must be at least two bytes")
+    val = int.from_bytes(seed[:2], "big")
+    val = (val + 0x4D2B) & 0xFFFF
+    val = ((val << 3) | (val >> 13)) & 0xFFFF
+    return val.to_bytes(2, "big")
+
+
+def crc16_ccitt(seed: bytes, data_record: bytes = b"") -> bytes:
+    """Compute a CRC16-CCITT over ``seed`` + ``data_record``."""
+
+    data = seed + data_record
+    poly = 0x1021
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ poly) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+    return crc.to_bytes(2, "big")
+
+
+# List of algorithms in recommended trial order
+DEFAULT_ALGOS: Iterable = (crc16_ccitt, xor_invert, add_rotate)

--- a/src/security_pretest.py
+++ b/src/security_pretest.py
@@ -1,0 +1,93 @@
+"""Helpers to automatically determine security access settings for a VCU.
+
+The routines here orchestrate the ISO 15765-2/UDS handshake used by the
+repository's diagnostics.  They try multiple data-record and key derivation
+algorithms until the ECU grants security access.  This mirrors the manual
+sequence used during reverse engineering:
+
+1. enter extended diagnostic session
+2. request seed and compute key
+3. read diagnostic trouble codes
+"""
+from __future__ import annotations
+
+from typing import Iterable, Callable, Tuple
+
+from uds import UDSClient, ISOTransportError
+from security_algorithms import DEFAULT_ALGOS
+
+
+def auto_security_access(
+    client: UDSClient,
+    level: int,
+    data_records: Iterable[bytes],
+    algorithms: Iterable[Callable[[bytes, bytes], bytes]] = DEFAULT_ALGOS,
+    timeout: float = 1.0,
+) -> Tuple[bytes, Callable[[bytes, bytes], bytes]]:
+    """Attempt security access using all combinations of records and algorithms.
+
+    Parameters
+    ----------
+    client:
+        Connected :class:`UDSClient` instance.
+    level:
+        Security access level to request.
+    data_records:
+        Iterable of supplier-specific data-record byte sequences to try.
+    algorithms:
+        Iterable of key-derivation callables.  Each receives ``(seed,
+        data_record)`` and returns the key bytes.
+    timeout:
+        Per-request timeout in seconds.
+
+    Returns
+    -------
+    Tuple of the successful ``data_record`` and algorithm.
+
+    Raises
+    ------
+    ISOTransportError
+        If none of the combinations grant security access.
+    """
+
+    for record in data_records:
+        for algo in algorithms:
+            try:
+                client.security_access(
+                    level,
+                    data_record=record,
+                    key_algo=algo,
+                    timeout=timeout,
+                )
+                return record, algo
+            except ISOTransportError as exc:  # pragma: no cover - exercised via tests
+                msg = str(exc)
+                if any(code in msg for code in ("0x35", "0x33", "0x24")):
+                    continue
+                raise
+    raise ISOTransportError("Unable to determine security settings")
+
+
+def run_basic_sequence(
+    client: UDSClient,
+    *,
+    session: int = 3,
+    level: int = 1,
+    data_records: Iterable[bytes] = (b"\x01\x01",),
+    algorithms: Iterable[Callable[[bytes, bytes], bytes]] = DEFAULT_ALGOS,
+    timeout: float = 1.0,
+) -> None:
+    """Execute the standard VCU handshake and read DTCs.
+
+    This function is intentionally minimal and suitable as a starting point for
+    integration tests.  It performs the sequence:
+
+    1. change diagnostic session
+    2. automatically unlock security access
+    3. read DTCs twice (emulating the observed VCU behaviour)
+    """
+
+    client.change_session(session, timeout)
+    auto_security_access(client, level, data_records, algorithms, timeout)
+    client.request(0x19, b"\x01\x01", timeout)
+    client.request(0x19, b"\x01\x01", timeout)

--- a/src/uds.py
+++ b/src/uds.py
@@ -48,27 +48,46 @@ def _nrc_desc(code: int) -> str:
     return _NRC_DESC.get(code, "Unknown error")
 
 
-def default_key_algo(seed: bytes) -> bytes:
-    """Fallback key algorithm performing a bitwise inversion."""
+def default_key_algo(seed: bytes, data_record: bytes = b"") -> bytes:
+    """Fallback key algorithm performing a bitwise inversion.
+
+    The optional ``data_record`` argument is accepted for compatibility with
+    algorithms that incorporate additional request bytes into the key
+    computation.  It is ignored by this simple implementation which merely
+    inverts the provided seed.
+    """
 
     return bytes((b ^ 0xFF) & 0xFF for b in seed)
 
 
 def _load_key_algo(
-    spec: "Callable[[bytes], bytes] | str | None",
-) -> "Callable[[bytes], bytes]":
-    """Resolve a key algorithm from a callable or ``module:attr`` string."""
+    spec: "Callable[..., bytes] | str | None",
+) -> "Callable[[bytes, bytes], bytes]":
+    """Resolve a key algorithm from a callable or ``module:attr`` string.
+
+    The returned callable always accepts ``(seed, data_record)`` but wrapped
+    functions may ignore the second argument if they only operate on the seed.
+    """
+
+    def _wrap(func: Callable[..., bytes]) -> "Callable[[bytes, bytes], bytes]":
+        def wrapped(seed: bytes, data_record: bytes = b"") -> bytes:
+            try:
+                return func(seed, data_record)  # type: ignore[misc]
+            except TypeError:
+                return func(seed)  # type: ignore[misc]
+
+        return wrapped
 
     if spec is None:
         return default_key_algo
     if callable(spec):
-        return spec
+        return _wrap(spec)
     if isinstance(spec, str):
         module_name, _, attr = spec.partition(":")
         module = importlib.import_module(module_name)
         algo = getattr(module, attr) if attr else module
         if callable(algo):
-            return algo  # type: ignore[arg-type]
+            return _wrap(algo)  # type: ignore[arg-type]
         raise TypeError("Security key algorithm is not callable")
     raise TypeError("Invalid key algorithm specification")
 
@@ -762,14 +781,21 @@ class UDSClient:
         return False
 
     def security_access(
-        self, level: int, key: "bytes | None" = None, timeout: float = 1.0
+        self,
+        level: int,
+        key: "bytes | None" = None,
+        *,
+        data_record: bytes = b"",
+        key_algo: "Callable[..., bytes] | str | None" = None,
+        timeout: float = 1.0,
     ) -> bool:
         """Request security access at ``level``.
 
         If ``key`` is ``None`` the key is derived from the ECU-provided seed
-        using ``key_algo`` specified at construction or via configuration.
-        ``key_algo`` may be a callable or a ``module:attr`` string which is
-        imported dynamically.
+        using ``key_algo`` specified at construction or via configuration.  The
+        optional ``data_record`` bytes are appended to the seed request and, when
+        generating a key, passed to the key algorithm.  ``key_algo`` may be a
+        callable or a ``module:attr`` string which is imported dynamically.
 
         Raises
         ------
@@ -779,7 +805,7 @@ class UDSClient:
         """
 
         self.logger.info("Requesting security access level %d", level)
-        rsp = self.request(0x27, bytes([level * 2 - 1]), timeout)
+        rsp = self.request(0x27, bytes([level * 2 - 1]) + data_record, timeout)
         if len(rsp) < 2:
             self.logger.error("Invalid seed response")
             raise ISOTransportError("Invalid seed response")
@@ -795,10 +821,11 @@ class UDSClient:
             self.logger.error("Unexpected seed response: %s", rsp.hex())
             raise ISOTransportError("Unexpected seed response")
         seed = rsp[2:]
+        algo = _load_key_algo(key_algo) if key_algo is not None else self._key_algo
         if key is None:
-            key = self._key_algo(seed)
+            key = algo(seed, data_record)
         self.logger.info("Submitting key for security level %d", level)
-        rsp2 = self.request(0x27, bytes([level * 2]) + key, timeout)
+        rsp2 = self.request(0x27, bytes([level * 2]) + data_record + key, timeout)
         if len(rsp2) < 2:
             self.logger.error("Invalid key response")
             raise ISOTransportError("Invalid key response")

--- a/tests/test_security_pretest.py
+++ b/tests/test_security_pretest.py
@@ -1,0 +1,81 @@
+import can
+import pytest
+
+from uds import UDSClient, ISOTransportError
+from security_algorithms import crc16_ccitt, xor_invert
+from security_pretest import auto_security_access
+
+
+def test_security_access_with_data_record(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
+    client = UDSClient(bus, 0x7E0, 0x7E8)
+
+    sent = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+
+    resp_seed = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x04, 0x67, 0x01, 0x12, 0x34, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    resp_key = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x02, 0x67, 0x02, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    responses = [resp_seed, resp_key]
+    monkeypatch.setattr(bus, "recv", lambda timeout: responses.pop(0))
+
+    record = b"\x01\x01"
+    key_expected = crc16_ccitt(b"\x12\x34", record)
+
+    assert client.security_access(1, data_record=record, key_algo=crc16_ccitt)
+    assert len(sent) == 2
+    assert bytes(sent[0].data)[:5] == bytes([0x04, 0x27, 0x01, 0x01, 0x01])
+    assert bytes(sent[1].data)[:7] == bytes([0x06, 0x27, 0x02, 0x01, 0x01]) + key_expected
+
+
+def test_auto_security_access(monkeypatch, bus_factory):
+    bus = bus_factory(bitrate=500000)
+    client = UDSClient(bus, 0x7E0, 0x7E8)
+
+    sent = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+
+    resp_seed1 = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x04, 0x67, 0x01, 0x12, 0x34, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    resp_neg = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x03, 0x7F, 0x27, 0x35, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    resp_seed2 = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x04, 0x67, 0x01, 0x56, 0x78, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    resp_key = can.Message(
+        arbitration_id=0x7E8,
+        data=bytes([0x02, 0x67, 0x02, 0, 0, 0, 0, 0]),
+        is_extended_id=False,
+    )
+    responses = [resp_seed1, resp_neg, resp_seed2, resp_key]
+
+    def fake_recv(timeout):
+        return responses.pop(0)
+
+    monkeypatch.setattr(bus, "recv", fake_recv)
+
+    record = b"\x01\x01"
+    key_ok = crc16_ccitt(b"\x56\x78", record)
+
+    used_record, algo = auto_security_access(
+        client, 1, [record], algorithms=[xor_invert, crc16_ccitt]
+    )
+    assert used_record == record
+    assert algo is crc16_ccitt
+    assert len(sent) == 4
+    assert bytes(sent[-1].data)[:7] == bytes([0x06, 0x27, 0x02, 0x01, 0x01]) + key_ok

--- a/uds_config.json
+++ b/uds_config.json
@@ -8,11 +8,11 @@
     "source_address": 241,
     "target_address": 16,
     "address_extension": null,
-    "flow_control": { "block_size": 1, "st_min_ms": 5 },
+    "flow_control": { "block_size": 1, "st_min_ms": 1 },
     "security": {
       "level": 1,
-      "key": [255, 255],
-      "algorithm": "xor"
+      "data_record": [1, 1],
+      "algorithm": "security_algorithms:xor_invert"
     },
     "dtcs": {
       "P058D": {
@@ -175,15 +175,39 @@
       "response_id": 2024
     },
     {
-      "name": "read_dtc",
+      "name": "request_seed",
       "can_id": 2016,
-      "payload": "03 19 02 FF 00 00 00 00",
+      "payload": "06 27 01 01 01 00 00 00",
       "response_id": 2024
     },
     {
-      "name": "flow_control",
+      "name": "send_key",
+      "can_id": 2016,
+      "payload": "06 27 02 01 FF FF 00 00 00",
+      "response_id": 2024
+    },
+    {
+      "name": "read_dtc1",
+      "can_id": 2016,
+      "payload": "03 19 01 01 00 00 00 00",
+      "response_id": 2024
+    },
+    {
+      "name": "read_dtc2",
+      "can_id": 2016,
+      "payload": "03 19 01 01 00 00 00 00",
+      "response_id": 2024
+    },
+    {
+      "name": "flow_control1",
       "can_id": 2024,
-      "payload": "30 01 05 00 00 00 00 00",
+      "payload": "30 01 01 00 00 00 00 00",
+      "response_id": null
+    },
+    {
+      "name": "flow_control2",
+      "can_id": 2024,
+      "payload": "30 01 01 00 00 00 00 00",
       "response_id": null
     }
   ],


### PR DESCRIPTION
## Summary
- support `data_record` and per-call key algorithms in `UDSClient.security_access`
- add common seed-key algorithms and automatic security pre-test helper
- document supplier-specific data record and algorithm probing
- update default configuration sequence and flow-control timing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b01723f1883249d7d934b2cd5e38a