### PR TITLE
Validate CAN payload length to prevent invalid frames

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -428,12 +428,18 @@ def _sequence_loop(
                 if uds_locked_out and data and data[0] == 0x27:
                     logger.warning("Skipping security access due to lockout")
                     continue
+                if len(data) > 8 and not step.get("is_fd", False):
+                    logger.error(
+                        "Payload for '%s' exceeds 8 bytes", step.get("name", hex(step["can_id"]))
+                    )
+                    continue
                 msg = can.Message(
                     arbitration_id=step["can_id"],
                     data=data,
                     is_extended_id=bool(
                         step.get("is_extended_id", step["can_id"] > 0x7FF)
                     ),
+                    is_fd=step.get("is_fd", len(data) > 8),
                 )
                 with bus_lock:
                     bus.send(msg)

--- a/uds_config.json
+++ b/uds_config.json
@@ -177,13 +177,13 @@
     {
       "name": "request_seed",
       "can_id": 2016,
-      "payload": "06 27 01 01 01 00 00 00",
+      "payload": "07 27 01 01 01 00 00 00",
       "response_id": 2024
     },
     {
       "name": "send_key",
       "can_id": 2016,
-      "payload": "06 27 02 01 FF FF 00 00 00",
+      "payload": "07 27 02 01 FF FF 00 00",
       "response_id": 2024
     },
     {


### PR DESCRIPTION
## Summary
- warn and skip when sequence payloads exceed 8 bytes
- mark frames as CAN FD when needed
- correct sample UDS sequence payload lengths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0cb29b8c8324b3db36f20c68418a