### PR TITLE
Handle oversized CAN payloads gracefully

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -425,6 +425,13 @@ def _sequence_loop(
             start = time.time()
             for step in sequence:
                 data = bytes.fromhex(step["payload"])
+                if len(data) > 8:
+                    logger.error(
+                        "Payload length %d exceeds 8 bytes for CAN frame '%s'",
+                        len(data),
+                        step.get("name", hex(step["can_id"])),
+                    )
+                    continue
                 if uds_locked_out and data and data[0] == 0x27:
                     logger.warning("Skipping security access due to lockout")
                     continue
@@ -435,8 +442,16 @@ def _sequence_loop(
                         step.get("is_extended_id", step["can_id"] > 0x7FF)
                     ),
                 )
-                with bus_lock:
-                    bus.send(msg)
+                try:
+                    with bus_lock:
+                        bus.send(msg)
+                except can.CanError as exc:  # pragma: no cover - depends on driver
+                    logger.error(
+                        "Failed to send frame '%s': %s",
+                        step.get("name", hex(step["can_id"])),
+                        exc,
+                    )
+                    continue
                 resp_id = step.get("response_id")
                 if resp_id is not None:
                     timeout = step.get("timeout_ms", 100) / 1000
@@ -813,16 +828,12 @@ def main(argv: Optional[list[str]] = None) -> int:
                                     )
                                 else:
                                     client.security_access(level, key)
-                                logger.info(
-                                    "UDS security level %s unlocked", level
-                                )
+                                logger.info("UDS security level %s unlocked", level)
                             except ISOTransportError as exc:
                                 logger.warning(
                                     "UDS security level %s denied: %s", level, exc
                                 )
-                                if any(
-                                    code in str(exc) for code in ("0x36", "0x37")
-                                ):
+                                if any(code in str(exc) for code in ("0x36", "0x37")):
                                     uds_locked_out = True
                     except Exception as exc:  # pragma: no cover - best effort
                         logger.warning("UDS initialisation failed: %s", exc)

--- a/tests/test_sequence_scheduler.py
+++ b/tests/test_sequence_scheduler.py
@@ -158,3 +158,28 @@ def test_sequence_loop_timeout_warns(monkeypatch, bus_factory, caplog):
     assert any(
         "No response to 'ping' request" in r.getMessage() for r in caplog.records
     )
+
+
+def test_sequence_loop_logs_on_long_payload(monkeypatch, bus_factory, caplog):
+    bus = bus_factory(bitrate=500000)
+    sent = []
+    monkeypatch.setattr(bus, "send", lambda msg, timeout=None: sent.append(msg))
+    stop = threading.Event()
+    seq = [
+        {
+            "name": "toolong",
+            "can_id": 0x123,
+            "payload": "001122334455667788",
+        }
+    ]
+    logger = logging.getLogger("seq")
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        t = threading.Thread(
+            target=_sequence_loop, args=(bus, seq, 20, None, logger, stop)
+        )
+        t.start()
+        time.sleep(0.05)
+        stop.set()
+        t.join()
+    assert not sent
+    assert any("exceeds 8 bytes" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- guard against CAN frames larger than 8 bytes in the sequence loop
- log and continue when CAN driver rejects a frame instead of crashing
- cover oversized payload handling with a new unit test

## Testing
- `pre-commit run --files src/can_monitor.py tests/test_sequence_scheduler.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0cb29b8c8324b3db36f20c68418a