### PR TITLE
Handle UDS security access timeouts

### DIFF
--- a/src/can_monitor.py
+++ b/src/can_monitor.py
@@ -833,8 +833,20 @@ def main(argv: Optional[list[str]] = None) -> int:
                                 logger.warning(
                                     "UDS security level %s denied: %s", level, exc
                                 )
-                                if any(code in str(exc) for code in ("0x36", "0x37")):
-                                    uds_locked_out = True
+                                # When security access fails we set the global
+                                # ``uds_locked_out`` flag to avoid hammering the
+                                # ECU with further authentication attempts.  This
+                                # is done for any failure, not only explicit
+                                # lockout negative response codes, as timeouts or
+                                # unexpected responses generally indicate the ECU
+                                # will not process subsequent requests in the
+                                # current session.  Disabling the configured
+                                # request sequence prevents repeated "No
+                                # response" warnings and mirrors real-world
+                                # behaviour where the diagnostic session would be
+                                # aborted after an authentication failure.
+                                uds_locked_out = True
+                                sequence_cfg = None
                     except Exception as exc:  # pragma: no cover - best effort
                         logger.warning("UDS initialisation failed: %s", exc)
                 if db is None and not fallback_dbs:

--- a/tests/test_can_monitor.py
+++ b/tests/test_can_monitor.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import can
 import pytest
+from uds import ISOTransportError
 
 import sys
 from pathlib import Path
@@ -184,6 +185,61 @@ def test_monitor_without_print_raw(log_setup, bus_factory):
     fmt = "08X" if msg.is_extended_id else "03X"
     expected = f"id=0x{msg.arbitration_id:{fmt}} decoded={expected_decoded}"
     assert expected in contents
+
+
+def test_security_access_failure_disables_sequence(monkeypatch, tmp_path):
+    """Security access errors should set lockout and skip the sequence."""
+    config = {
+        "uds": {
+            "ecu_request_id": 1,
+            "ecu_response_id": 2,
+            "security": {"level": 1, "key": "AA"},
+        },
+        "sequence": [
+            {"name": "enter_session", "can_id": 1, "payload": "01"}
+        ],
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(config))
+
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def change_session(self, sess):
+            return True
+
+        def security_access(self, level, key, data_record=b""):
+            raise ISOTransportError("Consecutive frame timeout")
+
+    class DummyBus:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def send(self, *args, **kwargs):
+            pass
+
+        def recv(self, *args, **kwargs):
+            return None
+
+    def fake_monitor(*args, **kwargs):
+        captured["sequence"] = kwargs.get("sequence")
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(can_monitor, "setup_interface", lambda *a, **k: None)
+    monkeypatch.setattr(can.interface, "Bus", lambda *a, **k: DummyBus())
+    monkeypatch.setattr(can_monitor, "UDSClient", DummyClient)
+    monkeypatch.setattr(can_monitor, "monitor", fake_monitor)
+    can_monitor.uds_locked_out = False
+
+    assert main(["--config", str(cfg_path), "--interface", "vcan0"]) == 0
+    assert can_monitor.uds_locked_out is True
+    assert captured["sequence"] is None
 
 
 def test_bus_off_raises_can_error(log_setup, monkeypatch, bus_factory):


### PR DESCRIPTION
## Summary
- abort further diagnostic requests when UDS security access fails
- exercise new behaviour with unit test verifying lockout and sequence suppression

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b1e649ebc8324af15b000fe15d9ef